### PR TITLE
[testing-on-gke] Refactor FIO output file parser

### DIFF
--- a/testing_on_gke/examples/dlio/parse_logs.py
+++ b/testing_on_gke/examples/dlio/parse_logs.py
@@ -269,12 +269,15 @@ if __name__ == "__main__":
 
   output = create_output_scenarios_from_downloaded_files(args)
 
-  output_file_path = args.output_file
-  # Create the parent directory of output_file_path if doesn't
-  # exist already.
-  ensure_directory_exists(os.path.dirname(output_file_path))
-  write_records_to_csv_output_file(output, output_file_path)
-  print(
-      "\n\nSuccessfully published outputs of DLIO test runs to"
-      f" {output_file_path} !!!\n\n"
-  )
+  if len(output) == 0:
+    print(f"\nNo DLIO outputs found for experiment_id {args.experiment_id} !\n")
+  else:
+    output_file_path = args.output_file
+    # Create the parent directory of output_file_path if doesn't
+    # exist already.
+    ensure_directory_exists(os.path.dirname(output_file_path))
+    write_records_to_csv_output_file(output, output_file_path)
+    print(
+        "\n\nSuccessfully published outputs of DLIO test runs to"
+        f" {output_file_path} !!!\n\n"
+    )

--- a/testing_on_gke/examples/fio/fio_workload.py
+++ b/testing_on_gke/examples/fio/fio_workload.py
@@ -162,7 +162,7 @@ class FioWorkload:
         f' blockSize:{self.blockSize}, filesPerThread:{self.filesPerThread},'
         f' numThreads:{self.numThreads}, bucket:{self.bucket},'
         f' readTypes:{self.readTypes}, gcsfuseMountOptions:'
-        f' {gcsfuseMountOptions}, numEpochs: {self.numEpochs}'
+        f' {self.gcsfuseMountOptions}, numEpochs: {self.numEpochs}'
     )
 
 

--- a/testing_on_gke/examples/fio/parse_logs.py
+++ b/testing_on_gke/examples/fio/parse_logs.py
@@ -17,8 +17,10 @@
 
 # standard library imports
 import argparse
+from collections.abc import Sequence
 import json
 import os
+from os import path
 import pprint
 import re
 import subprocess
@@ -32,7 +34,8 @@ from fio.bq_utils import FioBigqueryExporter, FioTableRow, Timestamp
 from utils.utils import unix_to_timestamp, convert_size_to_bytes
 
 _LOCAL_LOGS_LOCATION = "../../bin/fio-logs"
-_EPOCH_FILENAME_REGEX = "^epoch[0-9]+.json$"
+_EPOCH_FILENAME_REGEX = "^epoch[1-9][0-9]*.json$"
+_EPOCH_NUMBER_MATCH_REGEX = ".*epoch([1-9][0-9]*).json"
 
 record = {
     "pod_name": "",
@@ -81,13 +84,18 @@ def download_fio_outputs(fioWorkloads: set, experimentID: str) -> int:
     <_LOCAL_LOGS_LOCATION>/<experimentID>/<fileSize>/<fileSize>-<blockSize>-<numThreads>-<filesPerThread>-<hash>/gcsfuse-generic/<readType>/gcsfuse_mount_options
   """
 
+  # Find all the unique set of buckets, and then only
+  # download output files from them to avoid runtime
+  # wastage for multiple workloads using the same bucket.
+  buckets = set()
   for fioWorkload in fioWorkloads:
-    dstDir = (
-        _LOCAL_LOGS_LOCATION + "/" + experimentID + "/" + fioWorkload.fileSize
-    )
+    buckets.add(fioWorkload.bucket)
+
+  for bucket in buckets:
+    dstDir = path.join(_LOCAL_LOGS_LOCATION, experimentID, bucket)
     ensure_directory_exists(dstDir)
 
-    srcObjects = f"gs://{fioWorkload.bucket}/fio-output/{experimentID}/*"
+    srcObjects = f"gs://{bucket}/fio-output/{experimentID}/*"
     print(f"Downloading FIO outputs from {srcObjects} ...")
     returncode, errorStr = download_gcs_objects(srcObjects, dstDir)
     if returncode < 0:
@@ -108,8 +116,8 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
     <_LOCAL_LOGS_LOCATION>/<experimentID>/<fileSize>/<fileSize>-<blockSize>-<numThreads>-<filesPerThread>-<hash>/gcsfuse-generic/<readType>/gcsfuse_mount_options
 
     Output dict structure:
-    "{read_type}-{mean_file_size}-{bs}-{numjobs}-{nrfiles}":
-        "mean_file_size": str
+    "{read_type}-{file_size}-{bs}-{numjobs}-{nrfiles}":
+        "file_size": str
         "read_type": str
         "records":
             "local-ssd": [record1, record2, record3, ...]
@@ -151,7 +159,7 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
             metadata_values[metadata] = f.read().strip()
         else:
           print(
-              f"Error: Directory {root} does not have file {metadata} in it"
+              f"Warning: Directory {root} does not have file {metadata} in it"
               " as expected, so skipping it."
           )
           skip_this_directory = True
@@ -168,64 +176,109 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
       with open(per_epoch_output, "r") as f:
         try:
           per_epoch_output_data = json.load(f)
-        except:
-          print(f"failed to json-parse {per_epoch_output}, so skipping it.")
+        except Exception as e:
+          print(
+              f"Warning: failed to json-parse {per_epoch_output}, so skipping"
+              f" it. Error: {e}"
+          )
           continue
-
-      # Confirm that the per_epoch_output_data has ["jobs"][0]["job options"]['"bs"]
-      # for determining blocksize.
-      if (
-          not "jobs" in per_epoch_output_data
-          or not per_epoch_output_data["jobs"]
-          or not "job options" in per_epoch_output_data["jobs"][0]
-          or not "bs" in per_epoch_output_data["jobs"][0]["job options"]
-      ):
-        print(
-            'Did not find "[jobs][0][job options][bs]" in'
-            f" {per_epoch_output}, so ignoring this file"
-        )
-        continue
-      # Confirm that the per_epoch_output_data has ["global options"] for
-      # determining nrfiles and numjobs in it.
-      if "global options" not in per_epoch_output_data:
-        print(f"field: 'global options' missing in {per_epoch_output}")
-        continue
 
       # This print is for debugging in case something goes wrong.
       print(f"Now parsing file {per_epoch_output} ...")
 
-      # Get fileSize, readType, echo number from the file path.
+      # Get epoch number, and key from the file path.
       root_split = root.split("/")
-      mean_file_size = root_split[-4]
       key = root_split[
           -3
-      ]  # key is unique for a given combination of of fileSize,blockSize,numThreads(numjobs),filesPerThread(nrfiles).
+      ]  # key is unique identifier for a single FIO workload.
       scenario = root_split[-2]
-      read_type = root_split[-1]
-      epoch = int(file.split(".")[0][-1])
+      epoch = int(
+          re.match(_EPOCH_NUMBER_MATCH_REGEX, per_epoch_output).group(1)
+      )
 
-      # Get nrfiles,numjobs, blocksize from ["global options"] and ["job options"].
+      # Confirm that the per_epoch_output_data has all the required attributes.
+      for attr in {"global options", "jobs", "timestamp_ms"}:
+        if not attr in per_epoch_output_data:
+          print(
+              f"Warning: '{attr}' missing in FIO output file"
+              f" {per_epoch_output}, so skipping this file."
+          )
+          continue
       global_options = per_epoch_output_data["global options"]
+      jobs = per_epoch_output_data["jobs"]
+      timestamp_ms = per_epoch_output_data["timestamp_ms"]
+
+      for attr in {"nrfiles", "numjobs", "ioengine", "direct", "iodepth"}:
+        if not attr in global_options:
+          print(
+              f"Warning: '{attr}' missing in 'global options' in FIO output"
+              f" file {per_epoch_output}, so skipping this file."
+          )
+          continue
       nrfiles = int(global_options["nrfiles"])
       numjobs = int(global_options["numjobs"])
-      job0 = per_epoch_output_data["jobs"][0]
 
-      bs = job0["job options"]["bs"]
+      if not isinstance(jobs, Sequence) or len(jobs) == 0:
+        print(
+            f"Warning: No jobs found in FIO output file {per_epoch_output}, so"
+            " skipping this file."
+        )
+        continue
+      elif len(jobs) > 1:
+        print(
+            "Warning: More than 1 job found in FIO output file"
+            f" {per_epoch_output}, which is not supported, so skipping this"
+            " file."
+        )
+        continue
+      job0 = jobs[0]
+
+      for attr in ["job options", "read", "job_start"]:
+        if not attr in job0:
+          print(
+              f'Warning: Did not find "[jobs][0][{attr}]" in'
+              f" {per_epoch_output}, so skipping this file."
+          )
+          continue
+      job0_options = job0["job options"]
+      job0_read_metrics = job0["read"]
+      job0_start = job0["job_start"]
+
+      if not isinstance(job0_options, dict):
+        print(
+            'Warning: "[jobs][0][job options]" is not of type dict in'
+            f" {per_epoch_output}, so skipping this file"
+        )
+        continue
+
+      for attr in ["bs", "filesize", "rw"]:
+        if not attr in job0_options:
+          print(
+              f'Warning: Did not find "[jobs][0][job options][{attr}]" in'
+              f" {per_epoch_output}, so skipping this file"
+          )
+          continue
+      bs = job0_options["bs"]
+      file_size = job0_options["filesize"]
+      read_type = job0_options["rw"]
 
       # If the record for this key has not been added, create a new entry
       # for it.
       if key not in output:
         output[key] = {
-            "mean_file_size": mean_file_size,
+            "file_size": file_size,
             "read_type": read_type,
             "records": {
-                "local-ssd": [],
-                "gcsfuse-generic": [],
+                scenario: [],
             },
         }
 
-      job0_read_metrics = job0["read"]
-      bs = job0["job options"]["bs"]
+      if not isinstance(job0_read_metrics, dict):
+        print(
+            "Warning: jobs[0]['read'] is not of type dict in"
+            f" {per_epoch_output}, so skipping this file."
+        )
+        continue
 
       # Create a record for this key.
       r = record.copy()
@@ -243,10 +296,10 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
         r["throughput_mb_per_second"] = round(
             (r["throughput_bytes_per_second"] / 1e6), 2
         )
-        r["start_epoch"] = job0["job_start"] // 1000
-        r["end_epoch"] = per_epoch_output_data["timestamp_ms"] // 1000
-        r["start"] = unix_to_timestamp(job0["job_start"])
-        r["end"] = unix_to_timestamp(per_epoch_output_data["timestamp_ms"])
+        r["start_epoch"] = job0_start // 1000
+        r["end_epoch"] = timestamp_ms // 1000
+        r["start"] = unix_to_timestamp(job0_start)
+        r["end"] = unix_to_timestamp(timestamp_ms)
 
         fetch_cpu_memory_data(args=args, record=r)
 
@@ -262,8 +315,9 @@ def create_output_scenarios_from_downloaded_files(args: dict) -> dict:
         r["e2e_latency_ns_p99.9"] = clat_ns_percentile["99.900000"]
       except Exception as e:
         print(
-            f"Failed to create following record with error: {e}, metadata:"
-            f" {repr(metadata_values)}"
+            f"Warning: failed to create record for key {key} for FIO output"
+            f" file {per_epoch_output} with error: {e}, metadata:"
+            f" {repr(metadata_values)}, so skipping this file."
         )
         # This print is for debugging in case something goes wrong.
         pprint.pprint(r)
@@ -331,7 +385,7 @@ def write_records_to_csv_output_file(output: dict, output_file_path: str):
             continue
 
           output_file_fwr.write(
-              f"{record_set['mean_file_size']},{record_set['read_type']},{scenario},{r['epoch']},{r['duration']},{r['throughput_mib_per_second']},{r['IOPS']},{r['throughput_over_local_ssd']},{r['lowest_memory']},{r['highest_memory']},{r['lowest_cpu']},{r['highest_cpu']},{r['pod_name']},{r['start']},{r['end']},\"{r['gcsfuse_mount_options']}\",{r['blockSize']},{r['filesPerThread']},{r['numThreads']},{args.experiment_id},"
+              f"{record_set['file_size']},{record_set['read_type']},{scenario},{r['epoch']},{r['duration']},{r['throughput_mib_per_second']},{r['IOPS']},{r['throughput_over_local_ssd']},{r['lowest_memory']},{r['highest_memory']},{r['lowest_cpu']},{r['highest_cpu']},{r['pod_name']},{r['start']},{r['end']},\"{r['gcsfuse_mount_options']}\",{r['blockSize']},{r['filesPerThread']},{r['numThreads']},{args.experiment_id},"
           )
           output_file_fwr.write(
               f"{r['e2e_latency_ns_max']},{r['e2e_latency_ns_p50']},{r['e2e_latency_ns_p90']},{r['e2e_latency_ns_p99']},{r['e2e_latency_ns_p99.9']},"
@@ -375,7 +429,7 @@ def write_records_to_bq_table(
         row.experiment_id = experiment_id
         row.epoch = r["epoch"]
         row.operation = record_set["read_type"]
-        row.file_size = record_set["mean_file_size"]
+        row.file_size = record_set["file_size"]
         row.file_size_in_bytes = convert_size_to_bytes(row.file_size)
         row.block_size = r["blockSize"]
         row.block_size_in_bytes = convert_size_to_bytes(row.block_size)
@@ -429,26 +483,28 @@ if __name__ == "__main__":
     download_fio_outputs(fioWorkloads, args.experiment_id)
 
   output = create_output_scenarios_from_downloaded_files(args)
+  if len(output) == 0:
+    print(f"\nNo FIO outputs found for experiment_id {args.experiment_id} !\n")
+  else:
+    # Export output dict to CSV.
+    output_file_path = args.output_file
+    # Create the parent directory of output_file_path if doesn't exist already.
+    ensure_directory_exists(os.path.dirname(output_file_path))
+    write_records_to_csv_output_file(output, output_file_path)
 
-  # Export output dict to CSV.
-  output_file_path = args.output_file
-  # Create the parent directory of output_file_path if doesn't exist already.
-  ensure_directory_exists(os.path.dirname(output_file_path))
-  write_records_to_csv_output_file(output, output_file_path)
-
-  # Export output dict to bigquery table.
-  if (
-      args.bq_project_id
-      and args.bq_project_id.strip()
-      and args.bq_dataset_id
-      and args.bq_dataset_id.strip()
-      and args.bq_table_id
-      and args.bq_table_id.strip()
-  ):
-    write_records_to_bq_table(
-        output=output,
-        bq_project_id=args.bq_project_id,
-        bq_dataset_id=args.bq_dataset_id,
-        bq_table_id=args.bq_table_id,
-        experiment_id=args.experiment_id,
-    )
+    # Export output dict to bigquery table.
+    if (
+        args.bq_project_id
+        and args.bq_project_id.strip()
+        and args.bq_dataset_id
+        and args.bq_dataset_id.strip()
+        and args.bq_table_id
+        and args.bq_table_id.strip()
+    ):
+      write_records_to_bq_table(
+          output=output,
+          bq_project_id=args.bq_project_id,
+          bq_dataset_id=args.bq_dataset_id,
+          bq_table_id=args.bq_table_id,
+          experiment_id=args.experiment_id,
+      )

--- a/testing_on_gke/examples/fio/run_tests.py
+++ b/testing_on_gke/examples/fio/run_tests.py
@@ -94,7 +94,7 @@ def main(args) -> None:
   helmInstallCommands = createHelmInstallCommands(
       fioWorkloads, args.experiment_id, args.machine_type, args.custom_csi_driver
   )
-  buckets = (fioWorkload.bucket for fioWorkload in fioWorkloads)
+  buckets = {fioWorkload.bucket for fioWorkload in fioWorkloads}
   role = 'roles/storage.objectUser'
   add_iam_role_for_buckets(
       buckets,


### PR DESCRIPTION
Clone of
https://github.com/GoogleCloudPlatform/gcsfuse/commit/abfec4839a9c1b76cf051fa43937e9912d6b74f3 .

* Refactor FIO output file parser

1. Parse filesize, blocksize, read_type from FIO output file rather than from the output file path.
2. Add more error checks on FIO output files being malformed.
3. Support FIO output files with epoch numbers > 9.

* mean_file_size -> file_size

* fix logs

* ignore FIO output files containing more than 1 job

* more refactoring and error checks

* fix a local variable name

* fix logs