### PR TITLE
[testing-on-gke][FIO jobFile support part-1] Support jobFile in fioWorkload

### DIFF
--- a/testing_on_gke/examples/fio/fio_workload.py
+++ b/testing_on_gke/examples/fio/fio_workload.py
@@ -75,22 +75,22 @@ def validate_fio_workload(workload: dict, name: str):
       )
       return False
   else:
-  for requiredAttribute, expectedType in {
-      'fileSize': str,
-      'blockSize': str,
-      'filesPerThread': int,
-      'numThreads': int,
-  }.items():
-    if requiredAttribute not in fioWorkload:
-      print(f'In {name}, fioWorkload does not have {requiredAttribute} in it')
-      return False
-    if not type(fioWorkload[requiredAttribute]) is expectedType:
-      print(
-          f'In {name}, fioWorkload[{requiredAttribute}] is of type'
-          f' {type(fioWorkload[requiredAttribute])}, expected:'
-          f' {expectedType} '
-      )
-      return False
+    for requiredAttribute, expectedType in {
+        'fileSize': str,
+        'blockSize': str,
+        'filesPerThread': int,
+        'numThreads': int,
+    }.items():
+      if requiredAttribute not in fioWorkload:
+        print(f'In {name}, fioWorkload does not have {requiredAttribute} in it')
+        return False
+      if not type(fioWorkload[requiredAttribute]) is expectedType:
+        print(
+            f'In {name}, fioWorkload[{requiredAttribute}] is of type'
+            f' {type(fioWorkload[requiredAttribute])}, expected:'
+            f' {expectedType} '
+        )
+        return False
 
   if 'readTypes' in fioWorkload:
     readTypes = fioWorkload['readTypes']
@@ -206,7 +206,7 @@ def parse_test_config_for_fio_workloads(fioTestConfigFile: str):
       if not validate_fio_workload(workload, f'workload#{i}'):
         print(f'workloads#{i} is not a valid FIO workload, so ignoring it.')
       else:
-          fioWorkload = workload['fioWorkload']
+        fioWorkload = workload['fioWorkload']
         fioWorkloadAttributes = dict()
         if 'jobFile' in fioWorkload:
           fioWorkloadAttributes['jobFile'] = fioWorkload['jobFile']
@@ -221,15 +221,15 @@ def parse_test_config_for_fio_workloads(fioTestConfigFile: str):
         for attr in ['bucket', 'gcsfuseMountOptions']:
           fioWorkloadAttributes[attr] = workload[attr]
         fioWorkloadAttributes['readTypes'] = (
-                      fioWorkload['readTypes']
-                      if 'readTypes' in fioWorkload
-                      else ['read', 'randread']
+            fioWorkload['readTypes']
+            if 'readTypes' in fioWorkload
+            else ['read', 'randread']
         )
         fioWorkloadAttributes['numEpochs'] = (
-                      workload['numEpochs']
-                      if 'numEpochs' in workload
-                      else DefaultNumEpochs
-          )
+            workload['numEpochs']
+            if 'numEpochs' in workload
+            else DefaultNumEpochs
+        )
         for scenario in scenarios:
           fioWorkloadAttributes['scenario'] = scenario
           fioWorkloads.append(FioWorkload(**fioWorkloadAttributes))
@@ -260,10 +260,10 @@ def FioChartNamePodName(
   )
   return (
       (
-      f'fio-load-{shortForScenario}-{shortForReadType}-{fioWorkload.fileSize.lower()}-{hashOfWorkload}',
-      f'fio-tester-{shortForScenario}-{shortForReadType}-{fioWorkload.fileSize.lower()}-{hashOfWorkload}',
-      f'{experimentID}/{fioWorkload.fileSize}-{fioWorkload.blockSize}-{fioWorkload.numThreads}-{fioWorkload.filesPerThread}-{hashOfWorkload}/{fioWorkload.scenario}/{readType}',
-  )
+          f'fio-load-{shortForScenario}-{shortForReadType}-{fioWorkload.fileSize.lower()}-{hashOfWorkload}',
+          f'fio-tester-{shortForScenario}-{shortForReadType}-{fioWorkload.fileSize.lower()}-{hashOfWorkload}',
+          f'{experimentID}/{fioWorkload.fileSize}-{fioWorkload.blockSize}-{fioWorkload.numThreads}-{fioWorkload.filesPerThread}-{hashOfWorkload}/{fioWorkload.scenario}/{readType}',
+      )
       if not fioWorkload.jobFile
       else (
           f'fio-load-{shortForScenario}-{shortForReadType}-{hashOfWorkload}',

--- a/testing_on_gke/examples/fio/fio_workload.py
+++ b/testing_on_gke/examples/fio/fio_workload.py
@@ -25,7 +25,20 @@ DefaultNumEpochs = 4
 
 
 def validate_fio_workload(workload: dict, name: str):
-  """Validates the given json workload object."""
+  """Validates the given json workload object for a FIO workload.
+
+  It confirms that the passed workload object has a dict as value for key
+  'fioWorkload'. The workload object should also This fioWorkload dict should
+  either have (a) the key 'jobFile' or (b) keys 'fileSize', 'blockSize',
+  'numThreads',
+  'filesPerThread' etc, or both (a) and (b). If 'jobFile' is specified, then the
+  values of fileSize etc are ignored. The function also does checks on the types
+  and the
+  values of all these fields.
+  It also confirms that the passed workload object has strings as values for
+  keys 'gcsfuseMountOptions', and 'bucket', and optionally an integer value for
+  key 'numEpochs'.
+  """
   for requiredWorkloadAttribute, expectedType in {
       'bucket': str,
       'gcsfuseMountOptions': str,
@@ -147,9 +160,9 @@ class FioWorkload:
   "implicit-dirs,file_mode=777,file-cache:enable-parallel-downloads:true,metadata-cache:ttl-secs:true".
   9. numEpochs: Number of runs of the fio workload. Default is DefaultNumEpochs
   if missing.
-  10. jobFile: The path of a FIO job-file . When this is specified, it will
-  override the values of
-  fileSize, blockSize, filesPerThreads, numThreads, readTypes.
+  10. jobFile: The path of a FIO job-file . When jobFile is specified, the
+  values of
+  fileSize, blockSize, filesPerThreads, numThreads will not be used.
   """
 
   def __init__(

--- a/testing_on_gke/examples/fio/fio_workload.py
+++ b/testing_on_gke/examples/fio/fio_workload.py
@@ -24,7 +24,7 @@ import json
 DefaultNumEpochs = 4
 
 
-def validateFioWorkload(workload: dict, name: str):
+def validate_fio_workload(workload: dict, name: str):
   """Validates the given json workload object."""
   for requiredWorkloadAttribute, expectedType in {
       'bucket': str,
@@ -60,6 +60,21 @@ def validateFioWorkload(workload: dict, name: str):
     return False
 
   fioWorkload = workload['fioWorkload']
+  if 'jobFile' in fioWorkload:
+    jobFile = fioWorkload['jobFile'].strip()
+    if len(jobFile) == 0:
+      print(
+          '{name} has jobFile attribute in it, but it is empty, so ignoring'
+          ' this workload.'
+      )
+      return False
+    elif ' ' in jobFile:
+      print(
+          '{name} has jobFile attribute in it, but it has space (" ") in it, so'
+          ' ignoring this workload.'
+      )
+      return False
+  else:
   for requiredAttribute, expectedType in {
       'fileSize': str,
       'blockSize': str,
@@ -132,19 +147,23 @@ class FioWorkload:
   "implicit-dirs,file_mode=777,file-cache:enable-parallel-downloads:true,metadata-cache:ttl-secs:true".
   9. numEpochs: Number of runs of the fio workload. Default is DefaultNumEpochs
   if missing.
+  10. jobFile: The path of a FIO job-file . When this is specified, it will
+  override the values of
+  fileSize, blockSize, filesPerThreads, numThreads, readTypes.
   """
 
   def __init__(
       self,
       scenario: str,
-      fileSize: str,
-      blockSize: str,
-      filesPerThread: int,
-      numThreads: int,
       bucket: str,
       readTypes: list,
       gcsfuseMountOptions: str,
       numEpochs: int = DefaultNumEpochs,
+      fileSize: str = None,
+      blockSize: str = None,
+      filesPerThread: int = None,
+      numThreads: int = None,
+      jobFile: str = None,
   ):
     self.scenario = scenario
     self.fileSize = fileSize
@@ -155,6 +174,7 @@ class FioWorkload:
     self.readTypes = set(readTypes)
     self.gcsfuseMountOptions = gcsfuseMountOptions
     self.numEpochs = numEpochs
+    self.jobFile = jobFile
 
   def PPrint(self):
     print(
@@ -162,7 +182,8 @@ class FioWorkload:
         f' blockSize:{self.blockSize}, filesPerThread:{self.filesPerThread},'
         f' numThreads:{self.numThreads}, bucket:{self.bucket},'
         f' readTypes:{self.readTypes}, gcsfuseMountOptions:'
-        f' {self.gcsfuseMountOptions}, numEpochs: {self.numEpochs}'
+        f' {self.gcsfuseMountOptions}, numEpochs: {self.numEpochs}, jobFile:'
+        f' {self.jobFile}'
     )
 
 
@@ -182,32 +203,36 @@ def parse_test_config_for_fio_workloads(fioTestConfigFile: str):
     )
     for i in range(len(workloads)):
       workload = workloads[i]
-      if not validateFioWorkload(workload, f'workload#{i}'):
+      if not validate_fio_workload(workload, f'workload#{i}'):
         print(f'workloads#{i} is not a valid FIO workload, so ignoring it.')
       else:
-        for scenario in scenarios:
           fioWorkload = workload['fioWorkload']
-          fioWorkloads.append(
-              FioWorkload(
-                  scenario,
-                  fioWorkload['fileSize'],
-                  fioWorkload['blockSize'],
-                  fioWorkload['filesPerThread'],
-                  fioWorkload['numThreads'],
-                  workload['bucket'],
-                  (
+        fioWorkloadAttributes = dict()
+        if 'jobFile' in fioWorkload:
+          fioWorkloadAttributes['jobFile'] = fioWorkload['jobFile']
+        else:
+          for attr in [
+              'fileSize',
+              'blockSize',
+              'numThreads',
+              'filesPerThread',
+          ]:
+            fioWorkloadAttributes[attr] = fioWorkload[attr]
+        for attr in ['bucket', 'gcsfuseMountOptions']:
+          fioWorkloadAttributes[attr] = workload[attr]
+        fioWorkloadAttributes['readTypes'] = (
                       fioWorkload['readTypes']
                       if 'readTypes' in fioWorkload
                       else ['read', 'randread']
-                  ),
-                  workload['gcsfuseMountOptions'],
-                  numEpochs=(
+        )
+        fioWorkloadAttributes['numEpochs'] = (
                       workload['numEpochs']
                       if 'numEpochs' in workload
                       else DefaultNumEpochs
-                  ),
-              )
           )
+        for scenario in scenarios:
+          fioWorkloadAttributes['scenario'] = scenario
+          fioWorkloads.append(FioWorkload(**fioWorkloadAttributes))
   return fioWorkloads
 
 
@@ -234,7 +259,15 @@ def FioChartNamePodName(
       '-', ''
   )
   return (
+      (
       f'fio-load-{shortForScenario}-{shortForReadType}-{fioWorkload.fileSize.lower()}-{hashOfWorkload}',
       f'fio-tester-{shortForScenario}-{shortForReadType}-{fioWorkload.fileSize.lower()}-{hashOfWorkload}',
       f'{experimentID}/{fioWorkload.fileSize}-{fioWorkload.blockSize}-{fioWorkload.numThreads}-{fioWorkload.filesPerThread}-{hashOfWorkload}/{fioWorkload.scenario}/{readType}',
+  )
+      if not fioWorkload.jobFile
+      else (
+          f'fio-load-{shortForScenario}-{shortForReadType}-{hashOfWorkload}',
+          f'fio-tester-{shortForScenario}-{shortForReadType}-{hashOfWorkload}',
+          f'{experimentID}/{hashOfWorkload}/{fioWorkload.scenario}/{readType}',
+      )
   )

--- a/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -59,22 +59,29 @@ spec:
         apt-get update
         apt-get install -y libaio-dev gcc make git time wget
 
+        {{ if .Values.fio.jobFile }}
+        job_file={{ .Values.fio.jobFile }}
+        {{ else }}
         no_of_files_per_thread={{ .Values.fio.filesPerThread }}
         block_size={{ .Values.fio.blockSize }}
         file_size={{ .Values.fio.fileSize }}
         num_of_threads={{ .Values.fio.numThreads }}
+        {{ end }}
 
-        {{ if eq .Values.scenario "local-ssd" }}
+        {{ if or .Values.fio.jobFile (eq .Values.scenario "local-ssd") }}
         echo "Installing gcloud..."
         apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
         curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
         echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
         apt-get update && apt-get install -y google-cloud-cli
 
+        {{ if eq .Values.scenario "local-ssd" }}
         gcloud storage cp -r gs://{{ .Values.bucketName }}/* /data
 
         echo "Sleeping 5 minutes to wait for Local SSD RAID to populate data."
         sleep 300
+        {{ end }}
+
         {{ end }}
 
         # We are building fio from source because of the issue: https://github.com/axboe/fio/issues/1668.
@@ -92,6 +99,13 @@ spec:
 
         echo "Preparing fio config file..."
         filename=/fio_loading_test_job.fio
+
+        {{ if .Values.fio.jobFile }}
+
+        gcloud storage cp -v {{.Values.fio.jobFile}} $filename
+
+        {{ else }}
+
         {{ if eq .Values.fio.fileSize "200G" }}
         cat > $filename << EOF
         [global]
@@ -120,6 +134,8 @@ spec:
         {{ else }}
         wget -O $filename https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/master/perfmetrics/scripts/job_files/read_cache_load_test.fio
         {{ end }}
+
+        {{ end }} 
 
         echo "Setup default values..."
         epoch={{ .Values.numEpochs }}
@@ -153,7 +169,12 @@ spec:
         for i in $(seq $epoch); do
           echo "[Epoch ${i}] start time:" `date +%s`
           free -mh # Memory usage before workload start.
+          
+          {{ if .Values.fio.jobFile }}
+          READ_TYPE=$read_type DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="${output_dir}/epoch${i}.json"
+          {{ else }}
           NUMJOBS=$num_of_threads NRFILES=$no_of_files_per_thread FILE_SIZE=$file_size BLOCK_SIZE=$block_size READ_TYPE=$read_type DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="${output_dir}/epoch${i}.json"
+          {{ end }}
           free -mh # Memory usage after workload completion.
           echo "[Epoch ${i}] end time:" `date +%s`
 

--- a/testing_on_gke/examples/fio/loading-test/values.yaml
+++ b/testing_on_gke/examples/fio/loading-test/values.yaml
@@ -40,6 +40,7 @@ fio:
   blockSize: 64K
   filesPerThread: "20000"
   numThreads: "50"
+  jobFile: ""
 
 gcsfuse:
   metadataCacheTTLSeconds: "6048000"

--- a/testing_on_gke/examples/fio/run_tests.py
+++ b/testing_on_gke/examples/fio/run_tests.py
@@ -62,10 +62,6 @@ def createHelmInstallCommands(
             f'--set bucketName={fioWorkload.bucket}',
             f'--set scenario={fioWorkload.scenario}',
             f'--set fio.readType={readType}',
-            f'--set fio.fileSize={fioWorkload.fileSize}',
-            f'--set fio.blockSize={fioWorkload.blockSize}',
-            f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
-            f'--set fio.numThreads={fioWorkload.numThreads}',
             f'--set experimentID={experimentID}',
             (
                 '--set'
@@ -81,6 +77,17 @@ def createHelmInstallCommands(
             f'--set numEpochs={fioWorkload.numEpochs}',
             f'--set gcsfuse.customCSIDriver={customCSIDriver}',
         ]
+        if fioWorkload.jobFile:
+          commands.append(
+              f'--set fio.jobFile={fioWorkload.jobFile}',
+          )
+        else:
+          commands.extend([
+              f'--set fio.fileSize={fioWorkload.fileSize}',
+              f'--set fio.blockSize={fioWorkload.blockSize}',
+              f'--set fio.filesPerThread={fioWorkload.filesPerThread}',
+              f'--set fio.numThreads={fioWorkload.numThreads}',
+          ])
 
         helm_command = ' '.join(commands)
         helm_commands.append(helm_command)
@@ -92,7 +99,10 @@ def main(args) -> None:
       args.workload_config
   )
   helmInstallCommands = createHelmInstallCommands(
-      fioWorkloads, args.experiment_id, args.machine_type, args.custom_csi_driver
+      fioWorkloads,
+      args.experiment_id,
+      args.machine_type,
+      args.custom_csi_driver,
   )
   buckets = {fioWorkload.bucket for fioWorkload in fioWorkloads}
   role = 'roles/storage.objectUser'


### PR DESCRIPTION
### Description

Clone of https://github.com/GoogleCloudPlatform/gcsfuse/pull/3350 .

- Add `jobFile` in FioWorkload and in all related code. It takes precedence over other attributes `fileSize`, `blockSize` etc.
- Pass FioWorkload.jobFile as `fio.jobFile` to pod workload config through helm
- In the helm pod workload template, add support to download and use `fio.jobFile` instead of using `fio.fileSize` etc. when `fio.jobFile` has been passed.

This is followed up in #24 .

### Link to the issue in case of a bug fix.
[b/417969847](http://b/417969847)