### PR TITLE
[test_on_gke] [FIO jobFile support part-3] Add support for jobFileContent for when jobFile is a local-file on VM

### DIFF
--- a/testing_on_gke/examples/dlio/run_tests.py
+++ b/testing_on_gke/examples/dlio/run_tests.py
@@ -30,7 +30,7 @@ import sys
 
 # local imports from other directories
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'utils'))
-from run_tests_common import escape_commas_in_string, parse_args, run_command, add_iam_role_for_buckets
+from run_tests_common import escape_commas_in_helm_value, parse_args, run_command, add_iam_role_for_buckets
 from utils import UnknownMachineTypeError, resource_limits
 
 # local imports from same directory
@@ -38,7 +38,10 @@ import dlio_workload
 
 
 def createHelmInstallCommands(
-    dlioWorkloads: set, experimentID: str, machineType: str, customCSIDriver: str
+    dlioWorkloads: set,
+    experimentID: str,
+    machineType: str,
+    customCSIDriver: str,
 ) -> list:
   """Creates helm install commands for the given dlioWorkload objects."""
   helm_commands = []
@@ -70,7 +73,7 @@ def createHelmInstallCommands(
             f'--set experimentID={experimentID}',
             (
                 '--set'
-                f' gcsfuse.mountOptions={escape_commas_in_string(dlioWorkload.gcsfuseMountOptions)}'
+                f' gcsfuse.mountOptions={escape_commas_in_helm_value(dlioWorkload.gcsfuseMountOptions)}'
             ),
             f'--set nodeType={machineType}',
             f'--set podName={podName}',
@@ -93,7 +96,10 @@ def main(args) -> None:
       args.workload_config
   )
   helmInstallCommands = createHelmInstallCommands(
-      dlioWorkloads, args.experiment_id, args.machine_type, args.custom_csi_driver
+      dlioWorkloads,
+      args.experiment_id,
+      args.machine_type,
+      args.custom_csi_driver,
   )
   buckets = [dlioWorkload.bucket for dlioWorkload in dlioWorkloads]
   role = 'roles/storage.objectUser'

--- a/testing_on_gke/examples/fio/fio_workload.py
+++ b/testing_on_gke/examples/fio/fio_workload.py
@@ -158,8 +158,7 @@ def _serialize_job_file_content(jobFileRawContent: str) -> str:
   for unsupportedChar in UnsupportedCharsInFIOJobFile:
     if unsupportedChar in jobFileRawContent:
       raise Exception(
-          f'FIO jobFile {jobFile} has unsupported character'
-          f' "{unsupportedChar}".'
+          f'input string has unsupported character "{unsupportedChar}".'
       )
 
   jobFileContent = jobFileRawContent.replace(

--- a/testing_on_gke/examples/fio/fio_workload.py
+++ b/testing_on_gke/examples/fio/fio_workload.py
@@ -171,12 +171,11 @@ def _serialize_job_file_content(jobFileRawContent: str) -> str:
   # helm and shell evaluating them.
   # One backslash is needed to avoid the shell evaluating these constants.
   # Then two more backslashes are needed to avoid the helm install command
-  # evaluating added backslash and the slash itself.
+  # evaluating original added backslash and the backslash added to escape it.
   # As an example, helm install ... --set jobFileContent="filesize=\\\$FILESIZE",
   # get passed down to pod config as variable jobFileContent with value
   # "\$FILESIZE". This when dumped by shell into a file becomes
   # "filesize=$FILESIZE" which is the intended original config.
-  # TODO: handle it through a utility function.
   jobFileContent = jobFileContent.replace('$', r'\\\$')
 
   return jobFileContent

--- a/testing_on_gke/examples/fio/fio_workload_test.py
+++ b/testing_on_gke/examples/fio/fio_workload_test.py
@@ -430,6 +430,23 @@ directory=${DIR}
           case["expectedSerializedContent"],
       )
 
+  def test_serialize_job_file_content_failed(self):
+    cases = [
+        {"rawContent": r"""[global]
+# This is a comment, which will make this testcase fail.
+file_size=${FILE_SIZE}
+bs=64K
+[Workload]
+rw=randread
+directory=${DIR}
+"""},
+    ]
+    for case in cases:
+      with self.assertRaisesRegex(
+          Exception, "input string has unsupported character"
+      ):
+        _serialize_job_file_content(case["rawContent"])
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/testing_on_gke/examples/fio/fio_workload_test.py
+++ b/testing_on_gke/examples/fio/fio_workload_test.py
@@ -16,7 +16,7 @@
 """This file defines unit tests for functionalities in fio_workload.py"""
 
 import unittest
-from fio_workload import FioWorkload, validate_fio_workload
+from fio_workload import FioWorkload, _serialize_job_file_content, validate_fio_workload
 
 
 class FioWorkloadTest(unittest.TestCase):
@@ -406,6 +406,29 @@ class FioWorkloadTest(unittest.TestCase):
         "gcsfuseMountOptions": "implicit-dirs,cache-max-size:-1",
     })
     self.assertTrue(validate_fio_workload(workload, "valid-fio-workload-2"))
+
+  def test_serialize_job_file_content(self):
+    cases = [
+        {"rawContent": "", "expectedSerializedContent": ""},
+        {
+            "rawContent": r"""[global]
+file_size=${FILE_SIZE}
+bs=64K
+
+[Workload]
+rw=randread
+directory=${DIR}
+""",
+            "expectedSerializedContent": (
+                r"[global];file_size=\\\${FILE_SIZE};bs=64K;;[Workload];rw=randread;directory=\\\${DIR};"
+            ),
+        },
+    ]
+    for case in cases:
+      self.assertEqual(
+          _serialize_job_file_content(case["rawContent"]),
+          case["expectedSerializedContent"],
+      )
 
 
 if __name__ == "__main__":

--- a/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
+++ b/testing_on_gke/examples/fio/loading-test/templates/fio-tester.yaml
@@ -61,7 +61,7 @@ spec:
 
         {{ if .Values.fio.jobFile }}
         job_file={{ .Values.fio.jobFile }}
-        {{ else }}
+        {{ else if not .Values.fio.jobFileContent }}
         no_of_files_per_thread={{ .Values.fio.filesPerThread }}
         block_size={{ .Values.fio.blockSize }}
         file_size={{ .Values.fio.fileSize }}
@@ -100,7 +100,17 @@ spec:
         echo "Preparing fio config file..."
         filename=/fio_loading_test_job.fio
 
-        {{ if .Values.fio.jobFile }}
+        {{ if .Values.fio.jobFileContent }}
+        
+        # Deserialize the FIO jobfile content, replace ';'s with newlines
+        # and put it into a job file.
+        (echo "{{.Values.fio.jobFileContent}}" | tr ';' '\n') > $filename
+
+        # print the contents of the generated file for debugging
+        # in case the deserialization doesn't work as expected.
+        cat ${filename}
+
+        {{ else if .Values.fio.jobFile }}
 
         gcloud storage cp -v {{.Values.fio.jobFile}} $filename
 
@@ -134,12 +144,12 @@ spec:
         {{ else }}
         wget -O $filename https://raw.githubusercontent.com/GoogleCloudPlatform/gcsfuse/master/perfmetrics/scripts/job_files/read_cache_load_test.fio
         {{ end }}
+        read_type={{ .Values.fio.readType }}
 
         {{ end }} 
 
         echo "Setup default values..."
         epoch={{ .Values.numEpochs }}
-        read_type={{ .Values.fio.readType }}
         pause_in_seconds=20
         workload_dir=/data
 
@@ -165,12 +175,19 @@ spec:
         echo "{{ .Values.podName }}" > ${output_dir}/pod_name
         echo "{{ .Values.nodeType }}" > ${output_dir}/machine_type
         echo "{{ .Values.bucketName }}" > ${output_dir}/bucket_name
+        {{ if .Values.fio.jobFile }}
+        # Dump the name of the FIO job file into a file in the output directory for this workload.
+        echo "{{ .Values.fio.jobFile }}" > ${output_dir}/jobFile
+        {{ else if .Values.fio.jobFileContent }}
+        # Dump the FIO job file content into a file in the output directory for this workload.
+        echo "{{ .Values.fio.jobFileContent }}" > ${output_dir}/jobFileContent
+        {{ end }}
 
         for i in $(seq $epoch); do
           echo "[Epoch ${i}] start time:" `date +%s`
           free -mh # Memory usage before workload start.
 
-          {{ if .Values.fio.jobFile }}
+          {{ if or .Values.fio.jobFileContent .Values.fio.jobFile }}
           DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="${output_dir}/epoch${i}.json"
           {{ else }}
           NUMJOBS=$num_of_threads NRFILES=$no_of_files_per_thread FILE_SIZE=$file_size BLOCK_SIZE=$block_size READ_TYPE=$read_type DIR=$workload_dir fio ${filename} --alloc-size=1048576 --output-format=json --output="${output_dir}/epoch${i}.json"

--- a/testing_on_gke/examples/fio/loading-test/values.yaml
+++ b/testing_on_gke/examples/fio/loading-test/values.yaml
@@ -41,6 +41,7 @@ fio:
   filesPerThread: "20000"
   numThreads: "50"
   jobFile: ""
+  jobFileContent: ""
 
 gcsfuse:
   metadataCacheTTLSeconds: "6048000"

--- a/testing_on_gke/examples/fio/run_tests.py
+++ b/testing_on_gke/examples/fio/run_tests.py
@@ -29,7 +29,7 @@ import sys
 
 # local imports from other directories
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'utils'))
-from run_tests_common import escape_commas_in_string, parse_args, run_command, add_iam_role_for_buckets
+from run_tests_common import escape_commas_in_helm_value, parse_args, run_command, add_iam_role_for_buckets
 from utils import UnknownMachineTypeError, resource_limits
 
 # local imports from same directory
@@ -79,7 +79,7 @@ def createHelmInstallCommands(
           f'--set experimentID={experimentID}',
           (
               '--set'
-              f' gcsfuse.mountOptions={escape_commas_in_string(fioWorkload.gcsfuseMountOptions)}'
+              f' gcsfuse.mountOptions={escape_commas_in_helm_value(fioWorkload.gcsfuseMountOptions)}'
           ),
           f'--set nodeType={machineType}',
           f"--set resourceLimits.cpu={resourceLimits['cpu']}",
@@ -112,6 +112,22 @@ def createHelmInstallCommands(
                   moreHelmValues,
               )
           )
+      elif fioWorkload.jobFileContent:
+        chartName, podName, outputDirPrefix = fio_workload.FioChartNamePodName(
+            fioWorkload, experimentID
+        )
+        moreHelmValues = [
+            f'--set fio.jobFileContent={fioWorkload.jobFileContent}',
+        ]
+        helm_commands.append(
+            _create_helm_command(
+                chartName,
+                podName,
+                outputDirPrefix,
+                commonHelmValues,
+                moreHelmValues,
+            )
+        )
       else:
         chartName, podName, outputDirPrefix = fio_workload.FioChartNamePodName(
             fioWorkload, experimentID

--- a/testing_on_gke/examples/utils/run_tests_common.py
+++ b/testing_on_gke/examples/utils/run_tests_common.py
@@ -35,8 +35,8 @@ def run_command(command: str) -> int:
   return result.returncode
 
 
-def escape_commas_in_string(unescapedStr: str) -> str:
-  """Returns equivalent string with , replaced with \, ."""
+def escape_commas_in_helm_value(unescapedStr: str) -> str:
+  """Returns equivalent string with , replaced with \\, ."""
   return unescapedStr.replace(',', r'\,')
 
 

--- a/testing_on_gke/examples/utils/run_tests_common_test.py
+++ b/testing_on_gke/examples/utils/run_tests_common_test.py
@@ -14,19 +14,19 @@
 # limitations under the License.
 
 import unittest
-from run_tests_common import escape_commas_in_string
+from run_tests_common import escape_commas_in_helm_value
 
 
 class RunTestsCommonTest(unittest.TestCase):
 
-  def test_escape_commas_in_string(self):
+  def test_escape_commas_in_helm_value(self):
     tcs = [
         {"input": "a:b,c=d,", "expected_output": r"a:b\,c=d\,"},
         {"input": "", "expected_output": ""},
     ]
     for tc in tcs:
       self.assertEqual(
-          tc["expected_output"], escape_commas_in_string(tc["input"])
+          tc["expected_output"], escape_commas_in_helm_value(tc["input"])
       )
 
 


### PR DESCRIPTION
This is a clone of https://github.com/GoogleCloudPlatform/gcsfuse/pull/3357 .

### Description
If the passed FIO jobFile is a local file (not a GCS object), then read it, serialize it, and then encode it as helm config parameter jobFileContent.

This is dependent on #24 .

### Link to the issue in case of a bug fix.
[b/417969847](http://b/417969847)