### PR TITLE
fix: Use proper commit hash instead of using v3

### DIFF
--- a/create_csi_driver.sh
+++ b/create_csi_driver.sh
@@ -106,7 +106,9 @@ build_and_upload_gcsfuse() {
     git checkout "$BRANCH"
   fi
 
-  GOOS=linux GOARCH=amd64 go run tools/build_gcsfuse/main.go . . $(git rev-parse --short HEAD)
+COMMIT_HASH=$(git rev-parse --short HEAD)
+log "Building gcsfuse from commit ${COMMIT_HASH}"
+GOOS=linux GOARCH=amd64 go run tools/build_gcsfuse/main.go . . "${COMMIT_HASH}"
 
   log "Uploading gcsfuse binary to gs://$BUCKET/linux/amd64/"
   gcloud storage cp "./bin/gcsfuse" "gs://$BUCKET/linux/amd64/"

--- a/create_csi_driver.sh
+++ b/create_csi_driver.sh
@@ -106,7 +106,7 @@ build_and_upload_gcsfuse() {
     git checkout "$BRANCH"
   fi
 
-  GOOS=linux GOARCH=amd64 go run tools/build_gcsfuse/main.go . . v3
+  GOOS=linux GOARCH=amd64 go run tools/build_gcsfuse/main.go . . $(git rev-parse --short HEAD)
 
   log "Uploading gcsfuse binary to gs://$BUCKET/linux/amd64/"
   gcloud storage cp "./bin/gcsfuse" "gs://$BUCKET/linux/amd64/"


### PR DESCRIPTION
Use proper commit hash here instead of using v3 otherwise it will always show up as v3 in the sidecar logs (UserAgent).
