### PR TITLE
Add fio files to run data plane tests continuously on GKE testgrid

### DIFF
--- a/gke-fio-tests/README.md
+++ b/gke-fio-tests/README.md
@@ -1,0 +1,42 @@
+# FIO Tests for GKE
+
+This directory contains FIO job files designed for high scale performance benchmarking of GCSfuse on Google Kubernetes Engine (GKE). The tests are categorized into subdirectories based on the I/O pattern (e.g., `random_read`, `sequential_write`).
+
+## How to Use
+
+The FIO job files in this directory are templates that expect the target directory to be provided via an environment variable named `DIR`.
+
+To run these tests, you must set the `DIR` environment variable to the path of your GCSfuse mount point before invoking the `fio` command.
+
+### Example
+
+To run a specific FIO job file (e.g., `sequential_read/job.fio`) against a GCSfuse mount at `/my/gcs/mount`, you would use the following command:
+
+```bash
+DIR=/my/gcs/mount/fio_sequential_read fio sequential_read/job.fio
+```
+
+## Important: Pre-populating Data for Read Tests
+
+The scripts that run the scalability tests expect pre-existing data for read tests. Therefore, the FIO read-test job files in this directory are designed to run against pre-populated data. The GKE testgrid infrastructure uses the GCS bucket `gs://gcsfusecsi-list-storm-hns-bucket` for this purpose.
+
+**If you modify any of the read FIO job files** (e.g., `random_read/*.fio`), you **must** update the contents of the `gs://gcsfusecsi-list-storm-hns-bucket` to match the new test configuration (e.g., `filesize`, `nrfiles`).
+
+Failing to pre-populate the bucket with the correct data will cause the read tests to fail or produce invalid results.
+
+### Directory Structure for Pre-populated Data
+
+The test scripts expect the pre-populated data for read tests to follow a specific directory structure within the GCS bucket. For each read test suite located in a directory (e.g., `random_read`), the corresponding data must be placed in a directory named `fio_<test_suite_name>` at the root of the bucket.
+
+For example:
+
+*   For tests in `random_read/`, the data should be in `gs://gcsfusecsi-list-storm-hns-bucket/fio_random_read/`.
+*   For tests in `sequential_read/`, the data should be in `gs://gcsfusecsi-list-storm-hns-bucket/fio_sequential_read/`.
+
+You can use FIO to generate the necessary files locally and then upload them to the correct directory in the GCS bucket.
+
+**Example of generating and uploading data:**
+
+1.  Create a local directory: `mkdir -p /tmp/fio_random_read`
+2.  Run FIO to generate files based on the job file: `DIR=/tmp/fio_random_read fio gke-fio-tests/random_read/your_test_file.fio`
+3.  Upload the generated files to GCS: `gcloud storage cp -r /tmp/fio_random_read/* gs://gcsfusecsi-list-storm-hns-bucket/fio_random_read/`

--- a/gke-fio-tests/random_read/100MB.fio
+++ b/gke-fio-tests/random_read/100MB.fio
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[global]
+ioengine=libaio
+direct=1
+fadvise_hint=0
+iodepth=64
+invalidate=1
+thread=1
+openfiles=1
+group_reporting=1
+create_serialize=0
+allrandrepeat=0
+file_service_type=random
+numjobs=16
+filename_format=$jobname.$jobnum/$filenum
+
+[random_read_filesize_100M_blocksize_1M]
+stonewall
+directory=${DIR}
+bs=1M
+filesize=100MB
+rw=randread
+nrfiles=5

--- a/gke-fio-tests/random_read/10MB.fio
+++ b/gke-fio-tests/random_read/10MB.fio
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[global]
+ioengine=libaio
+direct=1
+fadvise_hint=0
+iodepth=64
+invalidate=1
+thread=1
+openfiles=1
+group_reporting=1
+create_serialize=0
+allrandrepeat=0
+file_service_type=random
+numjobs=16
+filename_format=$jobname.$jobnum/$filenum
+
+[random_read_filesize_10M_blocksize_1M]
+stonewall
+directory=${DIR}
+bs=1M
+filesize=10MB
+rw=randread
+nrfiles=10

--- a/gke-fio-tests/random_read/1MB.fio
+++ b/gke-fio-tests/random_read/1MB.fio
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[global]
+ioengine=libaio
+direct=1
+fadvise_hint=0
+iodepth=64
+invalidate=1
+thread=1
+openfiles=1
+group_reporting=1
+create_serialize=0
+allrandrepeat=0
+file_service_type=random
+numjobs=16
+filename_format=$jobname.$jobnum/$filenum
+
+[random_read_filesize_1M_blocksize_1M]
+stonewall
+directory=${DIR}
+bs=1M
+filesize=1MB
+rw=randread
+nrfiles=30

--- a/gke-fio-tests/sequential_read/100MB.fio
+++ b/gke-fio-tests/sequential_read/100MB.fio
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[global]
+ioengine=libaio
+direct=1
+fadvise_hint=0
+iodepth=64
+invalidate=1
+thread=1
+openfiles=1
+group_reporting=1
+create_serialize=0
+allrandrepeat=0
+file_service_type=random
+numjobs=16
+filename_format=$jobname.$jobnum/$filenum
+
+[sequential_read_filesize_100M_blocksize_1M]
+stonewall
+directory=${DIR}
+bs=1M
+filesize=100MB
+rw=read
+nrfiles=5

--- a/gke-fio-tests/sequential_read/10MB.fio
+++ b/gke-fio-tests/sequential_read/10MB.fio
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[global]
+ioengine=libaio
+direct=1
+fadvise_hint=0
+iodepth=64
+invalidate=1
+thread=1
+openfiles=1
+group_reporting=1
+create_serialize=0
+allrandrepeat=0
+file_service_type=random
+numjobs=16
+filename_format=$jobname.$jobnum/$filenum
+
+[sequential_read_filesize_10M_blocksize_1M]
+stonewall
+directory=${DIR}
+bs=1M
+filesize=10MB
+rw=read
+nrfiles=10

--- a/gke-fio-tests/sequential_read/1MB.fio
+++ b/gke-fio-tests/sequential_read/1MB.fio
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[global]
+ioengine=libaio
+direct=1
+fadvise_hint=0
+iodepth=64
+invalidate=1
+thread=1
+openfiles=1
+group_reporting=1
+create_serialize=0
+allrandrepeat=0
+file_service_type=random
+numjobs=16
+filename_format=$jobname.$jobnum/$filenum
+
+[sequential_read_filesize_1M_blocksize_1M]
+stonewall
+directory=${DIR}
+bs=1M
+filesize=1MB
+rw=read
+nrfiles=30

--- a/gke-fio-tests/sequential_write/1MB.fio
+++ b/gke-fio-tests/sequential_write/1MB.fio
@@ -1,0 +1,38 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[global]
+ioengine=sync
+direct=1
+fadvise_hint=0
+verify=0
+iodepth=64
+invalidate=1
+time_based=0
+file_append=0
+create_on_open=1
+thread=1
+openfiles=1
+group_reporting=1
+allrandrepeat=1
+numjobs=16
+filename_format=$jobname.$jobnum.$filenum
+
+[write_filesize_1M_blocksize_1M]
+stonewall
+directory=${DIR}
+bs=1M
+filesize=1MB
+rw=write
+nrfiles=20

--- a/gke-fio-tests/sequential_write/50MB.fio
+++ b/gke-fio-tests/sequential_write/50MB.fio
@@ -1,0 +1,38 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[global]
+ioengine=sync
+direct=1
+fadvise_hint=0
+verify=0
+iodepth=64
+invalidate=1
+time_based=0
+file_append=0
+create_on_open=1
+thread=1
+openfiles=1
+group_reporting=1
+allrandrepeat=1
+numjobs=16
+filename_format=$jobname.$jobnum.$filenum
+
+[write_filesize_50M_blocksize_1M]
+stonewall
+directory=${DIR}
+bs=1M
+filesize=50MB
+rw=write
+nrfiles=5


### PR DESCRIPTION
### Description
This PR adds the required fio files needed for running Data Plane tests on GKE Testgrid continuously.

### Link to the issue in case of a bug fix.
b/439585783
