### PR TITLE
Label in perf

### DIFF
--- a/perf-benchmarking-for-releases/README.md
+++ b/perf-benchmarking-for-releases/README.md
@@ -54,12 +54,13 @@ It should be executed from the `perf-benchmarking-for-releases` directory.
 ### Syntax
 
 ```bash
-bash run-benchmarks.sh <GCSFUSE_VERSION> <PROJECT_ID> <REGION> <MACHINE_TYPE> <IMAGE_FAMILY> <IMAGE_PROJECT>
+bash run-benchmarks.sh <GCSFUSE_VERSION> <LABEL> <PROJECT_ID> <REGION> <MACHINE_TYPE> <IMAGE_FAMILY> <IMAGE_PROJECT>
 ```
 
 ### Arguments:
 
 - `<GCSFUSE_VERSION>`: A Git tag (e.g., `v1.0.0`), branch name (e.g., `main`), or a commit ID on the GCSFuse master branch.
+- `<LABEL>`: A unique custom identifier for the benchmark run. This label is used to identify the results in BigQuery.
 - `<PROJECT_ID>`: Your Google Cloud Project ID in which you want the VM and Bucket to be created.
 - `<REGION>`: The GCP region where the VM and GCS buckets will be created (e.g., `us-south1`).
 - `<MACHINE_TYPE>`: The GCE machine type for the benchmark VM (e.g., `n2-standard-96`). This script supports attaching 16 local NVMe SSDs (375GB each) for LSSD-supported machine types.
@@ -68,9 +69,8 @@ bash run-benchmarks.sh <GCSFUSE_VERSION> <PROJECT_ID> <REGION> <MACHINE_TYPE> <I
 - `<IMAGE_PROJECT>`: The image project for the VM (e.g., `ubuntu-os-cloud`).
 
 ### Example:
-
 ```bash
-bash run-benchmarks.sh master gcs-fuse-test us-south1 n2-standard-96 ubuntu-2504-amd64 ubuntu-os-cloud
+bash run-benchmarks.sh master my-test-label gcs-fuse-test us-south1 n2-standard-96 ubuntu-2504-amd64 ubuntu-os-cloud
 ```
 
 ---
@@ -119,6 +119,21 @@ FIO benchmark results, including I/O statistics, latencies, and system resource 
 - **Project ID**: `gcs-fuse-test-ml`
 - **Dataset ID**: `gke_test_tool_outputs`
 - **Table ID**: `fio_outputs`
+
+You can query the results for a specific run using the `LABEL` you provided. The `fio_workload_id` column in BigQuery contains this label.
+
+**Example Query:**
+
+To retrieve all results for a run with the label `my-test-label`, use the following query:
+
+```sql
+SELECT
+  *
+FROM
+  `gcs-fuse-test-ml.gke_test_tool_outputs.fio_outputs`
+WHERE
+  fio_workload_id LIKE '%-my-test-label-%'
+```
 
 ---
 

--- a/perf-benchmarking-for-releases/README.md
+++ b/perf-benchmarking-for-releases/README.md
@@ -78,10 +78,10 @@ bash run-benchmarks.sh master my-test-label gcs-fuse-test us-south1 n2-standard-
 ## Workflow
 
 1. **Unique ID Generation**:  
-   A unique ID is generated based on the timestamp and a random suffix to name the VM and related GCS buckets.
+   A unique tracking ID is generated for each run based on the user-provided `<LABEL>`, the current timestamp, and a random suffix. This ID is used to tag results in BigQuery and organize them in GCS. To comply with cloud resource naming limits, a shorter version of this ID (without the label) is used to name the temporary VM and GCS test data bucket.
 
 2. **GCS Bucket Creation**:  
-   A GCS bucket `gcsfuse-release-benchmark-data-<UNIQUE_ID>` is created in the specified region to store FIO test data.
+   A GCS bucket for FIO test data is created in the specified region. Its name is generated dynamically to be unique for each run.
 
 3. **FIO Job File Upload**:  
    All `.fio` job files from the local `fio-job-files/` directory are uploaded to the results bucket.
@@ -139,6 +139,6 @@ WHERE
 
 ### Google Cloud Storage
 
-- **FIO Test Data:** The FIO test data (copied from `gs://gcsfuse-release-benchmark-fio-data`) is uploaded to a newly created bucket dynamically named `gcsfuse-release-benchmark-data-<UNIQUE_ID>`.
-- **Benchmark Results and FIO Job Files:** FIO JSON output files, benchmark logs, and FIO job files, are uploaded to the `gs://gcsfuse-release-benchmarks-results` bucket. The specific path within this bucket will be `gs://gcsfuse-release-benchmarks-results/<GCSFUSE_VERSION>-<UNIQUE_ID>/`.
+- **FIO Test Data:** The FIO test data (copied from `gs://gcsfuse-release-benchmark-fio-data`) is uploaded to a newly created bucket with a dynamically generated name (e.g., `gcsfuse-release-benchmark-data-20250826-100943-gcslklov`).
+- **Benchmark Results and FIO Job Files:** FIO JSON output files, benchmark logs, and FIO job files, are uploaded to the `gs://gcsfuse-release-benchmarks-results` bucket. The specific path within this bucket will be `gs://gcsfuse-release-benchmarks-results/<GCSFUSE_VERSION>-<LABEL>-<TIMESTAMP>-<RANDOM_SUFFIX>/`.
 - A `success.txt` file is uploaded to GCS upon successful completion of all benchmarks.

--- a/perf-benchmarking-for-releases/run-benchmarks.sh
+++ b/perf-benchmarking-for-releases/run-benchmarks.sh
@@ -14,15 +14,16 @@
 # limitations under the License.
 
 # Validate input arguments
-if [ "$#" -ne 6 ]; then
-    echo "Usage: $0 <GCSFUSE_VERSION> <PROJECT_ID> <REGION> <MACHINE_TYPE> <IMAGE_FAMILY> <IMAGE_PROJECT>"
+if [ "$#" -ne 7 ]; then
+    echo "Usage: $0 <GCSFUSE_VERSION> <LABEL> <PROJECT_ID> <REGION> <MACHINE_TYPE> <IMAGE_FAMILY> <IMAGE_PROJECT>"
     echo ""
     echo "<GCSFUSE_VERSION> can be a Git tag (e.g. v1.0.0), branch name (e.g. main), or a commit ID on master."
+    echo "<LABEL> is a unique custom identifier for the benchmark run. This is used to identify results in BigQuery."
     echo ""
     echo "This script should be run from the 'perf-benchmarking-for-releases' directory."
     echo ""
     echo "Example:"
-    echo "  bash run-benchmarks.sh master gcs-fuse-test us-south1 n2-standard-96 ubuntu-2504-amd64 ubuntu-os-cloud"
+    echo "  bash run-benchmarks.sh master my-test-label gcs-fuse-test us-south1 n2-standard-96 ubuntu-2504-amd64 ubuntu-os-cloud"
     exit 1
 fi
 
@@ -36,16 +37,17 @@ echo "Read access to:    gs://gcsfuse-release-benchmark-fio-data"
 echo "Read/Write access to: gs://gcsfuse-release-benchmarks-results"
 
 GCSFUSE_VERSION=$1
-PROJECT_ID=$2
-REGION=$3
-MACHINE_TYPE=$4
-IMAGE_FAMILY=$5
-IMAGE_PROJECT=$6
+LABEL=$2
+PROJECT_ID=$3
+REGION=$4
+MACHINE_TYPE=$5
+IMAGE_FAMILY=$6
+IMAGE_PROJECT=$7
 
 # Generate unique names for VM and buckets using timestamp and random number
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 RAND_SUFFIX=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
-UNIQUE_ID="${TIMESTAMP}-${RAND_SUFFIX}"
+UNIQUE_ID="${LABEL}-${TIMESTAMP}-${RAND_SUFFIX}"
 
 VM_NAME="gcsfuse-perf-benchmark-${UNIQUE_ID}"
 GCS_BUCKET_WITH_FIO_TEST_DATA="gcsfuse-release-benchmark-data-${UNIQUE_ID}"

--- a/perf-benchmarking-for-releases/run-benchmarks.sh
+++ b/perf-benchmarking-for-releases/run-benchmarks.sh
@@ -44,16 +44,22 @@ MACHINE_TYPE=$5
 IMAGE_FAMILY=$6
 IMAGE_PROJECT=$7
 
-# Generate unique names for VM and buckets using timestamp and random number
+# Sanitize LABEL to be DNS-compliant (lowercase, numbers, hyphens).
+SANITIZED_LABEL=$(echo "${LABEL}" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-' | sed -e 's/--\+/-/g' -e 's/^-//' -e 's/-$//')
+
+# Generate unique identifiers.
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
 RAND_SUFFIX=$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)
-UNIQUE_ID="${LABEL}-${TIMESTAMP}-${RAND_SUFFIX}"
+# An ID with the label for tracking results in BigQuery and GCS.
+UNIQUE_ID_WITH_LABEL="${SANITIZED_LABEL}-${TIMESTAMP}-${RAND_SUFFIX}"
+# A shorter ID without the label for resource names with character limits (VMs, GCS buckets).
+UNIQUE_ID_FOR_RESOURCES="${TIMESTAMP}-${RAND_SUFFIX}"
 
-VM_NAME="gcsfuse-perf-benchmark-${UNIQUE_ID}"
-GCS_BUCKET_WITH_FIO_TEST_DATA="gcsfuse-release-benchmark-data-${UNIQUE_ID}"
+VM_NAME="gcsfuse-perf-benchmark-${UNIQUE_ID_FOR_RESOURCES}"
+GCS_BUCKET_WITH_FIO_TEST_DATA="gcsfuse-release-benchmark-data-${UNIQUE_ID_FOR_RESOURCES}"
 RESULTS_BUCKET_NAME="gcsfuse-release-benchmarks-results"
 BQ_TABLE="gcs-fuse-test-ml.gke_test_tool_outputs.fio_outputs"
-RESULT_PATH="gs://${RESULTS_BUCKET_NAME}/${GCSFUSE_VERSION}-${UNIQUE_ID}"
+RESULT_PATH="gs://${RESULTS_BUCKET_NAME}/${GCSFUSE_VERSION}-${UNIQUE_ID_WITH_LABEL}"
 
 
 # For VM creation, we need a zone within the specified region.
@@ -153,7 +159,7 @@ gcloud compute instances create "${VM_NAME}" \
     --network-interface=network-tier=PREMIUM,nic-type=GVNIC \
     --scopes=https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/devstorage.read_write \
     --network-performance-configs=total-egress-bandwidth-tier=TIER_1 \
-    --metadata GCSFUSE_VERSION="${GCSFUSE_VERSION}",GCS_BUCKET_WITH_FIO_TEST_DATA="${GCS_BUCKET_WITH_FIO_TEST_DATA}",RESULT_PATH="${RESULT_PATH}",LSSD_ENABLED="${LSSD_ENABLED}",MACHINE_TYPE="${MACHINE_TYPE}",PROJECT_ID="${PROJECT_ID}",UNIQUE_ID="${UNIQUE_ID}" \
+    --metadata GCSFUSE_VERSION="${GCSFUSE_VERSION}",GCS_BUCKET_WITH_FIO_TEST_DATA="${GCS_BUCKET_WITH_FIO_TEST_DATA}",RESULT_PATH="${RESULT_PATH}",LSSD_ENABLED="${LSSD_ENABLED}",MACHINE_TYPE="${MACHINE_TYPE}",PROJECT_ID="${PROJECT_ID}",UNIQUE_ID="${UNIQUE_ID_WITH_LABEL}" \
     --metadata-from-file=startup-script=starter-script.sh \
     ${VM_LOCAL_SSD_ARGS}
 echo "VM created. Benchmarks will run on the VM."

--- a/perf-benchmarking-for-releases/starter-script.sh
+++ b/perf-benchmarking-for-releases/starter-script.sh
@@ -226,7 +226,7 @@ if [[ "$LSSD_ENABLED" == "true" ]]; then
     }
 fi
 
-git clone https://github.com/GoogleCloudPlatform/gcsfuse-tools.git
+git clone -b label-in-perf https://github.com/GoogleCloudPlatform/gcsfuse-tools.git
 cd gcsfuse-tools
 
 python3 -m venv py_venv

--- a/perf-benchmarking-for-releases/starter-script.sh
+++ b/perf-benchmarking-for-releases/starter-script.sh
@@ -155,7 +155,6 @@ RESULT_PATH=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instan
 LSSD_ENABLED=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/attributes/LSSD_ENABLED" -H "Metadata-Flavor: Google")
 PROJECT_ID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/attributes/PROJECT_ID" -H "Metadata-Flavor: Google")
 VM_NAME=$(hostname)
-UNIQUE_ID=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/attributes/UNIQUE_ID" -H "Metadata-Flavor: Google")
 GCSFUSE_MOUNT_OPTIONS_STR="implicit-dirs"
 
 # Determine system architecture
@@ -226,7 +225,7 @@ if [[ "$LSSD_ENABLED" == "true" ]]; then
     }
 fi
 
-git clone -b label-in-perf https://github.com/GoogleCloudPlatform/gcsfuse-tools.git
+git clone https://github.com/GoogleCloudPlatform/gcsfuse-tools.git
 cd gcsfuse-tools
 
 python3 -m venv py_venv

--- a/perf-benchmarking-for-releases/upload_fio_output_to_bigquery.py
+++ b/perf-benchmarking-for-releases/upload_fio_output_to_bigquery.py
@@ -71,7 +71,7 @@ parser.add_argument("--fio-job-file", required=True, help="Path to the temporary
 parser.add_argument("--master-fio-file", required=True, help="Path to the original master FIO job file")
 parser.add_argument("--project-id", default="gcs-fuse-test-ml", help="GCP project ID")
 parser.add_argument("--dataset-id", default="gke_test_tool_outputs", help="BigQuery dataset ID")
-parser.add_argument("--table-id", default="vipinydv_fio_outputs", help="BigQuery table ID")
+parser.add_argument("--table-id", default="fio_outputs", help="BigQuery table ID")
 parser.add_argument("--lowest-cpu", required=True, type=float, help="Lowest CPU usage")
 parser.add_argument("--highest-cpu", required=True, type=float, help="Highest CPU usage")
 parser.add_argument("--lowest-mem", required=True, type=float, help="Lowest Memory usage")

--- a/perf-benchmarking-for-releases/upload_fio_output_to_bigquery.py
+++ b/perf-benchmarking-for-releases/upload_fio_output_to_bigquery.py
@@ -71,7 +71,7 @@ parser.add_argument("--fio-job-file", required=True, help="Path to the temporary
 parser.add_argument("--master-fio-file", required=True, help="Path to the original master FIO job file")
 parser.add_argument("--project-id", default="gcs-fuse-test-ml", help="GCP project ID")
 parser.add_argument("--dataset-id", default="gke_test_tool_outputs", help="BigQuery dataset ID")
-parser.add_argument("--table-id", default="fio_outputs", help="BigQuery table ID")
+parser.add_argument("--table-id", default="vipinydv_fio_outputs", help="BigQuery table ID")
 parser.add_argument("--lowest-cpu", required=True, type=float, help="Lowest CPU usage")
 parser.add_argument("--highest-cpu", required=True, type=float, help="Highest CPU usage")
 parser.add_argument("--lowest-mem", required=True, type=float, help="Lowest Memory usage")


### PR DESCRIPTION
### Description
This PR adds a command-line flag to `run-benchmarks.sh` to allow users to specify a custom label for benchmark run IDs.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/441243836

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA
