### PR TITLE
Make the Docker images architecture-agnostic

### DIFF
--- a/npi/Makefile
+++ b/npi/Makefile
@@ -13,30 +13,28 @@
 # limitations under the License.
 
 GCSFUSE_VERSION ?= master
-ARCH ?= amd64
 GO_VERSION=1.25.0
 UBUNTU_VERSION=24.04
 REGISTRY=us-docker.pkg.dev
 
 .DEFAULT_GOAL := build
 
-.PHONY: build base read-benchmark write-benchmark
+.PHONY: build base read-benchmark write-benchmark orbax-benchmark
 
 base:
-	docker build -f gcsfuse-perf-base.docker --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg ARCH=$(ARCH) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-$(GCSFUSE_VERSION)-perf-base-$(ARCH):latest . && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-$(GCSFUSE_VERSION)-perf-base-$(ARCH):latest
+	docker buildx build --load -f gcsfuse-perf-base.docker --platform linux/amd64,linux/arm64 --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-$(GCSFUSE_VERSION)-perf-base:latest . && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-$(GCSFUSE_VERSION)-perf-base:latest
 
 read-benchmark: base
-	docker build fio -f fio/read.dockerfile --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg ARCH=$(ARCH) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg REGISTRY=$(REGISTRY) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-read-benchmark-$(GCSFUSE_VERSION)-$(ARCH):latest && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-read-benchmark-$(GCSFUSE_VERSION)-$(ARCH):latest
+	docker buildx build --load fio -f fio/read.dockerfile --platform linux/amd64,linux/arm64 --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg REGISTRY=$(REGISTRY) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-read-benchmark-$(GCSFUSE_VERSION):latest && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-read-benchmark-$(GCSFUSE_VERSION):latest
 
 write-benchmark: base
-	docker build fio -f fio/write.dockerfile --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg ARCH=$(ARCH) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg REGISTRY=$(REGISTRY) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-write-benchmark-$(GCSFUSE_VERSION)-$(ARCH):latest && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-write-benchmark-$(GCSFUSE_VERSION)-$(ARCH):latest
+	docker buildx build --load fio -f fio/write.dockerfile --platform linux/amd64,linux/arm64 --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg REGISTRY=$(REGISTRY) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-write-benchmark-$(GCSFUSE_VERSION):latest && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-write-benchmark-$(GCSFUSE_VERSION):latest
 
 fullsweep-benchmark: base
-	docker build fio -f fio/fullsweep.dockerfile --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg ARCH=$(ARCH) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg REGISTRY=$(REGISTRY) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-fullsweep-benchmark-$(GCSFUSE_VERSION)-$(ARCH):latest && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-fullsweep-benchmark-$(GCSFUSE_VERSION)-$(ARCH):latest
+	docker buildx build --load fio -f fio/fullsweep.dockerfile --platform linux/amd64,linux/arm64 --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg REGISTRY=$(REGISTRY) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-fullsweep-benchmark-$(GCSFUSE_VERSION):latest && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/fio-fullsweep-benchmark-$(GCSFUSE_VERSION):latest
 
 orbax-benchmark: base
-	docker build fio -f fio/orbax_emulated.dockerfile --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg ARCH=$(ARCH) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg REGISTRY=$(REGISTRY) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/orbax-emulated-benchmark-$(GCSFUSE_VERSION)-$(ARCH):latest && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/orbax-emulated-benchmark-$(GCSFUSE_VERSION)-$(ARCH):latest
+	docker buildx build --load fio -f fio/orbax_emulated.dockerfile --platform linux/amd64,linux/arm64 --build-arg GCSFUSE_VERSION=$(GCSFUSE_VERSION) --build-arg GO_VERSION=$(GO_VERSION) --build-arg UBUNTU_VERSION=$(UBUNTU_VERSION) --build-arg REGISTRY=$(REGISTRY) -t $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/orbax-emulated-benchmark-$(GCSFUSE_VERSION):latest && docker push $(REGISTRY)/gcs-fuse-test/gcsfuse-benchmarks/orbax-emulated-benchmark-$(GCSFUSE_VERSION):latest
 
 build: read-benchmark write-benchmark fullsweep-benchmark orbax-benchmark base
-
 

--- a/npi/fio/fio.dockerfile
+++ b/npi/fio/fio.dockerfile
@@ -1,10 +1,9 @@
 ARG UBUNTU_VERSION=24.04
 ARG GO_VERSION=1.24.5
-ARG ARCH=amd64
 ARG GCSFUSE_VERSION=master
 ARG REGISTRY=us-docker.pkg.dev
 
-FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-${GCSFUSE_VERSION}-perf-base-${ARCH}:latest
+FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-${GCSFUSE_VERSION}-perf-base:latest
 COPY run_fio_benchmark.py /run_fio_benchmark.py
 COPY fio_benchmark_runner.py /fio_benchmark_runner.py
 ENTRYPOINT ["/run_fio_benchmark.py"]

--- a/npi/fio/fullsweep.dockerfile
+++ b/npi/fio/fullsweep.dockerfile
@@ -1,10 +1,9 @@
 ARG UBUNTU_VERSION=24.04
 ARG GO_VERSION=1.24.5
-ARG ARCH=amd64
 ARG GCSFUSE_VERSION=master
 ARG REGISTRY=us-docker.pkg.dev
 
-FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-${GCSFUSE_VERSION}-perf-base-${ARCH}:latest
+FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-${GCSFUSE_VERSION}-perf-base:latest
 COPY run_fio_benchmark.py /run_fio_benchmark.py
 COPY fio_benchmark_runner.py /fio_benchmark_runner.py
 COPY run_fio_matrix.py /run_fio_matrix.py

--- a/npi/fio/orbax_emulated.dockerfile
+++ b/npi/fio/orbax_emulated.dockerfile
@@ -1,10 +1,9 @@
 ARG UBUNTU_VERSION=24.04
 ARG GO_VERSION=1.24.5
-ARG ARCH=amd64
 ARG GCSFUSE_VERSION=master
 ARG REGISTRY=us-docker.pkg.dev
 
-FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-${GCSFUSE_VERSION}-perf-base-${ARCH}:latest
+FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-${GCSFUSE_VERSION}-perf-base:latest
 COPY run_fio_benchmark.py /run_fio_benchmark.py
 COPY fio_benchmark_runner.py /fio_benchmark_runner.py
 COPY run_fio_matrix.py /run_fio_matrix.py

--- a/npi/fio/read.dockerfile
+++ b/npi/fio/read.dockerfile
@@ -1,10 +1,9 @@
 ARG UBUNTU_VERSION=24.04
 ARG GO_VERSION=1.24.5
-ARG ARCH=amd64
 ARG GCSFUSE_VERSION=master
 ARG REGISTRY=us-docker.pkg.dev
 
-FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-${GCSFUSE_VERSION}-perf-base-${ARCH}:latest
+FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-${GCSFUSE_VERSION}-perf-base:latest
 COPY run_fio_benchmark.py /run_fio_benchmark.py
 COPY fio_benchmark_runner.py /fio_benchmark_runner.py
 COPY run_fio_matrix.py /run_fio_matrix.py

--- a/npi/fio/write.dockerfile
+++ b/npi/fio/write.dockerfile
@@ -1,10 +1,9 @@
 ARG UBUNTU_VERSION=24.04
 ARG GO_VERSION=1.24.5
-ARG ARCH=amd64
 ARG GCSFUSE_VERSION=master
 ARG REGISTRY=us-docker.pkg.dev
 
-FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-${GCSFUSE_VERSION}-perf-base-${ARCH}:latest
+FROM ${REGISTRY}/gcs-fuse-test/gcsfuse-benchmarks/gcsfuse-${GCSFUSE_VERSION}-perf-base:latest
 COPY run_fio_benchmark.py /run_fio_benchmark.py
 COPY fio_benchmark_runner.py /fio_benchmark_runner.py
 COPY run_fio_matrix.py /run_fio_matrix.py

--- a/npi/gcsfuse-perf-base.docker
+++ b/npi/gcsfuse-perf-base.docker
@@ -1,46 +1,22 @@
 ARG UBUNTU_VERSION=24.04
 ARG GO_VERSION=1.24.5
-ARG ARCH=amd64
 ARG GCSFUSE_VERSION=master
 
-FROM ubuntu:${UBUNTU_VERSION} AS builder
-
-# Re-declare ARGs to make them available inside this build stage
-ARG GO_VERSION
-ARG ARCH
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS builder
 ARG GCSFUSE_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
+WORKDIR /app
+RUN git clone -b ${GCSFUSE_VERSION} --depth 1 --single-branch https://github.com/GoogleCloudPlatform/gcsfuse.git
+RUN cd gcsfuse && go build .
 
-# Set DEBIAN_FRONTEND to noninteractive to avoid prompts during package installation
-ENV DEBIAN_FRONTEND=noninteractive
-
-# Install dependencies
-RUN apt-get update -y && apt-get upgrade -y && \
-    apt-get install -y git wget make gcc
-
-# Download and install Go, then add it to the PATH
-RUN wget "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" -O go.tar.gz && \
-    tar -C /usr/local -xzf go.tar.gz
-ENV PATH="/usr/local/go/bin:${PATH}"
-
-# Clone GCSFuse repository, build it, and clean up apt cache
-RUN git clone -b ${GCSFUSE_VERSION} --depth 1 --single-branch https://github.com/GoogleCloudPlatform/gcsfuse.git && \
-    cd gcsfuse && go build .
-    
-
-FROM ubuntu:${UBUNTU_VERSION}
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y fuse3 python3-venv fio && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get autoremove -y && \
-    apt-get clean
-
-# Create and activate virtual environment to avoid PEP 668
-ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-# Install Python packages into the virtual environment
-RUN pip install --no-cache-dir google-cloud-bigquery
-COPY --from=builder /gcsfuse/gcsfuse /gcsfuse/gcsfuse
+FROM python:3.13
+# Install FUSE and related packages
+RUN apt-get update && apt-get install -y fuse3 fio \
+--no-install-recommends && \
+rm -rf /var/lib/apt/lists/* && \
+pip install --no-cache-dir google-cloud-bigquery
+COPY --from=builder /app/gcsfuse /gcsfuse/gcsfuse
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Make the Docker images architecture-agnostic so that they can run on both AMD64 as well as ARM64 architectures.