### PR TITLE
add matrix and failure links

### DIFF
--- a/release_analyser.py
+++ b/release_analyser.py
@@ -26,6 +26,33 @@ from collections import defaultdict
 TEST_PATTERN = re.compile(r'---\s+(PASS|FAIL|SKIP):\s+([^\s]+)')
 BENCHMARK_PATTERN = re.compile(r'(Benchmark_[^\s\-]+)')
 
+def get_display_width(s):
+    """Calculates the visual width of a string, counting emojis as width 2."""
+    width = 0
+    for c in s:
+        # Common emojis used in report
+        if c in ['✅', '❌', '⚠️', '⚪']:
+            width += 2
+        else:
+            width += 1
+    return width
+
+def pad_string(s, target_width, align='left'):
+    """Pads a string to a target display width."""
+    current_width = get_display_width(s)
+    padding_needed = target_width - current_width
+    if padding_needed <= 0:
+        return s
+    
+    if align == 'left':
+        return s + " " * padding_needed
+    elif align == 'right':
+        return " " * padding_needed + s
+    else: # center
+        left_pad = padding_needed // 2
+        right_pad = padding_needed - left_pad
+        return " " * left_pad + s + " " * right_pad
+
 # ==============================================================================
 
 # 1. LOG SYNCHRONIZATION
@@ -64,13 +91,20 @@ def sync_logs(bucket_name, release_version, vm_name_prefix, output_dir):
 
 def analyze_runtime_stats(parent_dir):
     """Parses package_runtime_stats.txt files to extract test results."""
-    results = defaultdict(lambda: defaultdict(lambda: {'passed': 0, 'failed': 0, 'flaky': 0}))
+    # results[btype][vm_name][pkg][attempt] = status_emoji
+    results = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
     files_processed = 0
+    parent_path = Path(parent_dir)
 
     # Find all package_runtime_stats.txt files in the given directory and subdirectories
-    for filepath in Path(parent_dir).rglob('package_runtime_stats.txt'):
+    for filepath in parent_path.rglob('package_runtime_stats.txt'):
         files_processed += 1
         
+        try:
+            vm_name = filepath.relative_to(parent_path).parts[0]
+        except Exception:
+            vm_name = "unknown_vm"
+            
         try:
             with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
                 for line in f:
@@ -86,13 +120,9 @@ def analyze_runtime_stats(parent_dir):
                         
                             
                         attempt = int(parts[5]) if len(parts) > 5 else 0
-                        if status_code == '0':
-                            if attempt > 0:
-                                results[btype][pkg]['flaky'] += 1
-                            else:
-                                results[btype][pkg]['passed'] += 1
-                        else:
-                            results[btype][pkg]['failed'] += 1
+                        status_emoji = '✅' if status_code == '0' else '❌'
+                        
+                        results[btype][vm_name][pkg][attempt] = status_emoji
         except Exception as e:
             print(f"Error reading {filepath}: {e}")
 
@@ -168,10 +198,12 @@ def generate_runtime_report(results, files_processed):
 def analyze_test_level_logs(parent_dir):
     """Parses individual test logs to extract specific test failures."""
     results = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: {'passed': 0, 'failed': 0, 'skipped': 0})))
+    failures = []
     target_folders = ['failed_package_logs', 'success_package_logs']
     files_processed = 0
+    parent_path = Path(parent_dir)
 
-    for filepath in Path(parent_dir).rglob('*.txt'):
+    for filepath in parent_path.rglob('*.txt'):
         parts = filepath.parts
         log_type = None
         for tf in target_folders:
@@ -185,6 +217,10 @@ def analyze_test_level_logs(parent_dir):
         bucket_type = filepath.parent.name
         package_name = filepath.stem
         
+        try:
+            vm_name = filepath.relative_to(parent_path).parts[0]
+        except Exception:
+            vm_name = "unknown_vm"
 
         files_processed += 1
         has_failures = False
@@ -209,6 +245,7 @@ def analyze_test_level_logs(parent_dir):
                         elif status == 'FAIL':
                             results[package_name][bucket_type][test_name]['failed'] += 1
                             has_failures = True
+                            failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': test_name})
                         elif status == 'SKIP':
                             results[package_name][bucket_type][test_name]['skipped'] += 1
                         continue
@@ -222,6 +259,7 @@ def analyze_test_level_logs(parent_dir):
                         elif log_type == 'failed_package_logs':
                             results[package_name][bucket_type][test_name]['failed'] += 1
                             has_failures = True
+                            failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': test_name})
 
                             
             # Edge Case: If the package log was dumped in the 'failed' directory but no specific 
@@ -231,11 +269,12 @@ def analyze_test_level_logs(parent_dir):
                 if dummy_name not in results[package_name][bucket_type]:
                     results[package_name][bucket_type][dummy_name] = {'passed': 0, 'failed': 0, 'skipped': 0}
                 results[package_name][bucket_type][dummy_name]['failed'] += 1
+                failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': dummy_name})
 
         except Exception as e:
             print(f"Error reading {filepath}: {e}")
 
-    return results, files_processed
+    return results, failures, files_processed
 
 
 def generate_test_level_report(results, files_processed):
@@ -313,7 +352,137 @@ def generate_test_level_report(results, files_processed):
                 print(row)
                 
             print("-" * len(header))
+# ==============================================================================
+# 4. MATRIX AND FAILURE REPORTING
+# ==============================================================================
 
+def generate_matrix_report(results, vm_name_prefix):
+    """Prints a matrix view of results per VM and Package."""
+    print("\n" + "=" * 80)
+    print(" GCSFUSE E2E MATRIX SUMMARY ".center(80, "="))
+    print("=" * 80)
+
+    if not results:
+        print("\nNo results to display.")
+        return
+
+    for btype, vms in sorted(results.items()):
+        print(f"\n>> BUCKET TYPE: [{btype.upper()}] <<\n")
+        
+        # Get all unique packages and VMs
+        all_packages = set()
+        all_vms = sorted(vms.keys())
+        for vm_name, pkgs in vms.items():
+            all_packages.update(pkgs.keys())
+        all_packages = sorted(list(all_packages))
+        
+        if not all_packages:
+            print("No packages found.")
+            continue
+            
+        # Shorten VM names for display
+        display_vms = []
+        for vm in all_vms:
+            if vm.startswith(vm_name_prefix):
+                d_vm = vm[len(vm_name_prefix):]
+                if d_vm.startswith("-"):
+                    d_vm = d_vm[1:]
+                display_vms.append(d_vm)
+            else:
+                display_vms.append(vm)
+        
+        # Calculate width for shortened VM name
+        max_vm_len = max([get_display_width(vm) for vm in display_vms] + [15])
+        
+        # Truncate package names to 10 chars for column headers
+        pkg_headers = [pkg[:10] for pkg in all_packages]
+        
+        # Build header line
+        header_parts = [pad_string('VM Name', max_vm_len)]
+        for pkg in pkg_headers:
+            header_parts.append(pad_string(pkg, 10))
+        
+        header = "| " + " | ".join(header_parts) + " |"
+        header_display_width = get_display_width(header)
+        
+        print("-" * header_display_width)
+        print(header)
+        print("-" * header_display_width)
+        
+        for i, vm in enumerate(all_vms):
+            display_vm = display_vms[i]
+            row_parts = [pad_string(display_vm, max_vm_len)]
+            
+            for pkg in all_packages:
+                attempts = vms[vm].get(pkg, {})
+                if not attempts:
+                    status_str = "⚪"
+                else:
+                    # Sort attempts by key
+                    sorted_attempts = [attempts[k] for k in sorted(attempts.keys())]
+                    # Take at most last 3
+                    last_attempts = sorted_attempts[-3:]
+                    status_str = "".join(last_attempts)
+                    
+                row_parts.append(pad_string(status_str, 10))
+                
+            row = "| " + " | ".join(row_parts) + " |"
+            print(row)
+            
+        print("-" * header_display_width)
+
+
+def generate_consolidated_failures_table(failures, bucket_name, release_version, vm_name_prefix):
+    """Prints a consolidated table of failures with HTTPS log links."""
+    print("\n" + "=" * 120)
+    print(" CONSOLIDATED FAILURES TABLE ".center(120, "="))
+    print("=" * 120)
+
+    if not failures:
+        print("\nNo failures found! 🎉")
+        return
+
+    formatted_failures = []
+    for f in failures:
+        vm = f['vm']
+        if vm.startswith(vm_name_prefix):
+            display_vm = vm[len(vm_name_prefix):]
+            if display_vm.startswith("-"):
+                display_vm = display_vm[1:]
+        else:
+            display_vm = vm
+            
+        link = f"https://console.cloud.google.com/storage/browser/{bucket_name}/{release_version}/{f['vm']}/failed-package-gcsfuse-logs"
+        
+        test_name = f['test']
+        if len(test_name) > 35:
+            test_name = test_name[:32] + "..."
+            
+        formatted_failures.append({
+            'bucket': f['bucket'].upper(),
+            'vm': display_vm,
+            'pkg': f['pkg'],
+            'test': test_name,
+            'link': link
+        })
+        
+    w_bucket = max([len(f['bucket']) for f in formatted_failures] + [6])
+    w_vm = max([len(f['vm']) for f in formatted_failures] + [15])
+    w_pkg = max([len(f['pkg']) for f in formatted_failures] + [20])
+    w_test = max([len(f['test']) for f in formatted_failures] + [35])
+    w_link = max([len(f['link']) for f in formatted_failures] + [50])
+    
+    header = f"| {'Bucket':<{w_bucket}} | {'VM':<{w_vm}} | {'Package':<{w_pkg}} | {'Test':<{w_test}} | {'Logs Link':<{w_link}} |"
+    
+    print("-" * len(header))
+    print(header)
+    print("-" * len(header))
+    
+    for f in formatted_failures:
+        row = f"| {f['bucket']:<{w_bucket}} | {f['vm']:<{w_vm}} | {f['pkg']:<{w_pkg}} | {f['test']:<{w_test}} | {f['link']:<{w_link}} |"
+        print(row)
+        
+    print("-" * len(header))
 
 
 # ==============================================================================
@@ -348,10 +517,35 @@ def main():
 
         # Step 2: Runtime Stats Analysis
         results_rt, count_rt = analyze_runtime_stats(output_dir)
-        generate_runtime_report(results_rt, count_rt)
+        
+        # Aggregate results for the old runtime report to avoid breaking it
+        from collections import defaultdict
+        aggregated_rt = defaultdict(lambda: defaultdict(lambda: {'passed': 0, 'failed': 0, 'flaky': 0}))
+        for btype, vms in results_rt.items():
+            for vm, pkgs in vms.items():
+                for pkg, attempts in pkgs.items():
+                    sorted_atts = sorted(attempts.keys())
+                    last_status = attempts[sorted_atts[-1]]
+                    if last_status == '✅':
+                        if len(sorted_atts) > 1:
+                            aggregated_rt[btype][pkg]['flaky'] += 1
+                        else:
+                            aggregated_rt[btype][pkg]['passed'] += 1
+                    else:
+                        aggregated_rt[btype][pkg]['failed'] += 1
+                        
+        generate_runtime_report(aggregated_rt, count_rt)
 
-        # Step 3: Test Level Logs Analysis
-        results_tl, count_tl = analyze_test_level_logs(output_dir)
+        # Step 3: Matrix Summary
+        generate_matrix_report(results_rt, args.vm_name_prefix)
+
+        # Step 4: Test Level Logs Analysis
+        results_tl, failures, count_tl = analyze_test_level_logs(output_dir)
+        
+        # Step 5: Consolidated Failures Table (Placed ABOVE detailed report)
+        generate_consolidated_failures_table(failures, args.release_bucket_name, args.release_version, args.vm_name_prefix)
+        
+        # Step 6: Detailed Test Level Report
         generate_test_level_report(results_tl, count_tl)
 
 

--- a/release_analyser.py
+++ b/release_analyser.py
@@ -206,7 +206,7 @@ def analyze_test_level_logs(parent_dir):
                         elif status == 'FAIL':
                             results[package_name][bucket_type][test_name][attempt] = '❌'
                             has_failures = True
-                            failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': test_name, 'e2e_run_folder': e2e_run_folder})
+                            failures.append({'vm': vm_name, 'pkg': filepath.stem, 'bucket': bucket_type, 'test': test_name, 'e2e_run_folder': e2e_run_folder})
                         elif status == 'SKIP':
                             results[package_name][bucket_type][test_name][attempt] = '⚪'
                         continue
@@ -220,7 +220,7 @@ def analyze_test_level_logs(parent_dir):
                         elif log_type == 'failed_package_logs':
                             results[package_name][bucket_type][test_name][attempt] = '❌'
                             has_failures = True
-                            failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': test_name, 'e2e_run_folder': e2e_run_folder})
+                            failures.append({'vm': vm_name, 'pkg': filepath.stem, 'bucket': bucket_type, 'test': test_name, 'e2e_run_folder': e2e_run_folder})
 
                             
             # Edge Case: If the package log was dumped in the 'failed' directory but no specific 
@@ -228,7 +228,7 @@ def analyze_test_level_logs(parent_dir):
             if log_type == 'failed_package_logs' and not has_failures:
                 dummy_name = "[PACKAGE_CRASH_OR_TIMEOUT]"
                 results[package_name][bucket_type][dummy_name][attempt] = '❌'
-                failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': dummy_name, 'e2e_run_folder': e2e_run_folder})
+                failures.append({'vm': vm_name, 'pkg': filepath.stem, 'bucket': bucket_type, 'test': dummy_name, 'e2e_run_folder': e2e_run_folder})
 
         except Exception as e:
             print(f"Error reading {filepath}: {e}")

--- a/release_analyser.py
+++ b/release_analyser.py
@@ -394,19 +394,28 @@ def generate_matrix_report(results, vm_name_prefix):
         # Calculate width for shortened VM name
         max_vm_len = max([get_display_width(vm) for vm in display_vms] + [15])
         
-        # Truncate package names to 10 chars for column headers
-        pkg_headers = [pkg[:10] for pkg in all_packages]
+        # Limit package names to 15 chars for vertical display
+        limit = 15
+        pkg_headers = [pkg[:limit] for pkg in all_packages]
+        pkg_headers_padded = [f"{pkg:<{limit}}" for pkg in pkg_headers]
         
-        # Build header line
-        header_parts = [pad_string('VM Name', max_vm_len)]
-        for pkg in pkg_headers:
-            header_parts.append(pad_string(pkg, 10))
-        
-        header = "| " + " | ".join(header_parts) + " |"
-        header_display_width = get_display_width(header)
+        # Build vertical headers
+        header_lines = []
+        for row_idx in range(limit):
+            if row_idx == limit - 1:
+                parts = [f"{'VM Name':<{max_vm_len}}"]
+            else:
+                parts = [f"{' ':<{max_vm_len}}"]
+                
+            for pkg in pkg_headers_padded:
+                parts.append(f"{pkg[row_idx]:^6}")
+            header_lines.append("| " + " | ".join(parts) + " |")
+            
+        header_display_width = get_display_width(header_lines[0])
         
         print("-" * header_display_width)
-        print(header)
+        for line in header_lines:
+            print(line)
         print("-" * header_display_width)
         
         for i, vm in enumerate(all_vms):
@@ -424,7 +433,7 @@ def generate_matrix_report(results, vm_name_prefix):
                     last_attempts = sorted_attempts[-3:]
                     status_str = "".join(last_attempts)
                     
-                row_parts.append(pad_string(status_str, 10))
+                row_parts.append(pad_string(status_str, 6))
                 
             row = "| " + " | ".join(row_parts) + " |"
             print(row)
@@ -465,6 +474,8 @@ def generate_consolidated_failures_table(failures, bucket_name, release_version,
             'test': test_name,
             'link': link
         })
+        
+    formatted_failures.sort(key=lambda x: (x['vm'], x['pkg'], x['test']))
         
     w_bucket = max([len(f['bucket']) for f in formatted_failures] + [6])
     w_vm = max([len(f['vm']) for f in formatted_failures] + [15])

--- a/release_analyser.py
+++ b/release_analyser.py
@@ -273,19 +273,19 @@ def generate_test_level_report(results, files_processed):
                 
                 total_exec = len(attempts)
                 
-                # Construct status string by sorting attempts
-                sorted_atts = [attempts[k] for k in sorted(attempts.keys())]
-                status_label = "".join(sorted_atts)
-                
-                # For sorting by status severity
+                # Determine status label
                 if failed > 0 and passed == 0:
                     status_val = 1
+                    status_label = "FAILED ❌"
                 elif failed > 0 and passed > 0:
                     status_val = 2
+                    status_label = "FLAKY ⚠️"
                 elif passed > 0:
                     status_val = 3
+                    status_label = "PASSED ✅"
                 else:
                     status_val = 4
+                    status_label = "SKIPPED"
                     
                 stats.append({
                     'test': test_name,

--- a/release_analyser.py
+++ b/release_analyser.py
@@ -18,6 +18,7 @@ import re
 import argparse
 import subprocess
 import tempfile
+import contextlib
 
 from pathlib import Path
 from collections import defaultdict
@@ -48,6 +49,10 @@ def pad_string(s, target_width, align='left'):
         return s + " " * padding_needed
     elif align == 'right':
         return " " * padding_needed + s
+    elif align == 'center':
+        left_pad = padding_needed // 2
+        right_pad = padding_needed - left_pad
+        return " " * left_pad + s + " " * right_pad
     else: # center
         left_pad = padding_needed // 2
         right_pad = padding_needed - left_pad
@@ -118,10 +123,14 @@ def analyze_runtime_stats(parent_dir):
                         btype = parts[1]
                         status_code = parts[2]
                         
+                        # Auto-increment attempt if not provided in file
+                        if len(parts) > 5:
+                            attempt = int(parts[5])
+                        else:
+                            existing_attempts = results[btype][vm_name][pkg]
+                            attempt = max(existing_attempts.keys()) + 1 if existing_attempts else 1
                             
-                        attempt = int(parts[5]) if len(parts) > 5 else 0
                         status_emoji = '✅' if status_code == '0' else '❌'
-                        
                         results[btype][vm_name][pkg][attempt] = status_emoji
         except Exception as e:
             print(f"Error reading {filepath}: {e}")
@@ -129,66 +138,7 @@ def analyze_runtime_stats(parent_dir):
     return results, files_processed
 
 
-def generate_runtime_report(results, files_processed):
-    """Prints the report for runtime stats."""
-    print("\n" + "=" * 80)
-    print(" GCSFUSE E2E RUNTIME STATS ANALYSIS REPORT ".center(80, "="))
-    print("=" * 80)
-    print(f"Total Log Files Processed: {files_processed}")
-    print("-" * 80)
 
-    if not results:
-        print("\nNo runtime stats found. Please check if package_runtime_stats.txt files were synced.")
-        return
-
-    # Process each bucket type separately
-    for btype, packages in sorted(results.items()):
-        print(f"\n>> BUCKET TYPE: [{btype.upper()}] <<\n")
-        
-        # Calculate stats and sort
-        stats = []
-        for pkg, counts in packages.items():
-            passed = counts['passed']
-            failed = counts['failed']
-            flaky = counts.get('flaky', 0)
-            total = passed + failed + flaky
-            
-            # Categorize status enum
-            if failed > 0:
-                status_enum = 1
-                status = "FAILED ❌"
-            elif flaky > 0:
-                status_enum = 2
-                status = "FLAKY ⚠️"
-            else:
-                status_enum = 3
-                status = "PASSED ✅"
-                
-            stats.append({
-                'pkg': pkg,
-                'total': total,
-                'passed': passed,
-                'failed': failed,
-                'flaky': flaky,
-                'status_enum': status_enum,
-                'status': status
-            })
-            
-        # Sort by status enum (FAILED -> FLAKY -> PASSED), then by fails descending
-        stats.sort(key=lambda x: (x['status_enum'], -x['failed'], -x['flaky']))
-        
-        # Print Table Header
-        header = f"| {'Package Name':<30} | {'Total':<7} | {'Passed':<6} | {'Flaky':<6} | {'Failed':<8} | {'Status':<12} |"
-        print("-" * len(header))
-        print(header)
-        print("-" * len(header))
-        
-        # Print Table Rows
-        for s in stats:
-            row = f"| {s['pkg']:<30} | {s['total']:<7} | {s['passed']:<6} | {s['flaky']:<6} | {s['failed']:<8} | {s['status']:<12} |"
-            print(row)
-            
-        print("-" * len(header))
 
 
 # ==============================================================================
@@ -197,7 +147,8 @@ def generate_runtime_report(results, files_processed):
 
 def analyze_test_level_logs(parent_dir):
     """Parses individual test logs to extract specific test failures."""
-    results = defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: {'passed': 0, 'failed': 0, 'skipped': 0})))
+    # results[pkg][btype][test][attempt] = emoji
+    results = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
     failures = []
     target_folders = ['failed_package_logs', 'success_package_logs']
     files_processed = 0
@@ -205,6 +156,11 @@ def analyze_test_level_logs(parent_dir):
 
     for filepath in parent_path.rglob('*.txt'):
         parts = filepath.parts
+        e2e_run_folder = None
+        for p in parts:
+            if p.startswith('gcsfuse-e2e-run-'):
+                e2e_run_folder = p
+                break
         log_type = None
         for tf in target_folders:
             if tf in parts:
@@ -216,6 +172,12 @@ def analyze_test_level_logs(parent_dir):
             
         bucket_type = filepath.parent.name
         package_name = filepath.stem
+        
+        # Extract attempt number from filename
+        attempt_match = re.search(r'_attempt_(\d+)$', package_name)
+        attempt = int(attempt_match.group(1)) if attempt_match else 1
+        
+        package_name = re.sub(r'_attempt_\d+$', '', package_name)
         
         try:
             vm_name = filepath.relative_to(parent_path).parts[0]
@@ -230,7 +192,7 @@ def analyze_test_level_logs(parent_dir):
                 for line in f:
                     if "flags empty: no tests to run" in line:
                         test_name = "<INCOMPATIBLE>"
-                        results[package_name][bucket_type][test_name]['skipped'] += 1
+                        results[package_name][bucket_type][test_name][attempt] = '⚪'
                         continue
 
                     test_match = TEST_PATTERN.search(line)
@@ -239,15 +201,14 @@ def analyze_test_level_logs(parent_dir):
                         status = test_match.group(1).upper()
                         test_name = test_match.group(2)
                         
-                            
                         if status == 'PASS':
-                            results[package_name][bucket_type][test_name]['passed'] += 1
+                            results[package_name][bucket_type][test_name][attempt] = '✅'
                         elif status == 'FAIL':
-                            results[package_name][bucket_type][test_name]['failed'] += 1
+                            results[package_name][bucket_type][test_name][attempt] = '❌'
                             has_failures = True
-                            failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': test_name})
+                            failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': test_name, 'e2e_run_folder': e2e_run_folder})
                         elif status == 'SKIP':
-                            results[package_name][bucket_type][test_name]['skipped'] += 1
+                            results[package_name][bucket_type][test_name][attempt] = '⚪'
                         continue
 
                     bench_match = BENCHMARK_PATTERN.search(line)
@@ -255,21 +216,19 @@ def analyze_test_level_logs(parent_dir):
                         test_name = bench_match.group(1)
                             
                         if log_type == 'success_package_logs':
-                            results[package_name][bucket_type][test_name]['passed'] += 1
+                            results[package_name][bucket_type][test_name][attempt] = '✅'
                         elif log_type == 'failed_package_logs':
-                            results[package_name][bucket_type][test_name]['failed'] += 1
+                            results[package_name][bucket_type][test_name][attempt] = '❌'
                             has_failures = True
-                            failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': test_name})
+                            failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': test_name, 'e2e_run_folder': e2e_run_folder})
 
                             
             # Edge Case: If the package log was dumped in the 'failed' directory but no specific 
             # '--- FAIL:' lines were printed, the test binary panicked, failed to compile, or timed out.
             if log_type == 'failed_package_logs' and not has_failures:
                 dummy_name = "[PACKAGE_CRASH_OR_TIMEOUT]"
-                if dummy_name not in results[package_name][bucket_type]:
-                    results[package_name][bucket_type][dummy_name] = {'passed': 0, 'failed': 0, 'skipped': 0}
-                results[package_name][bucket_type][dummy_name]['failed'] += 1
-                failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': dummy_name})
+                results[package_name][bucket_type][dummy_name][attempt] = '❌'
+                failures.append({'vm': vm_name, 'pkg': package_name, 'bucket': bucket_type, 'test': dummy_name, 'e2e_run_folder': e2e_run_folder})
 
         except Exception as e:
             print(f"Error reading {filepath}: {e}")
@@ -293,7 +252,7 @@ def generate_test_level_report(results, files_processed):
     groups = []
     for package_name, buckets in results.items():
         for bucket_type, tests in buckets.items():
-            total_failures = sum(t['failed'] for t in tests.values())
+            total_failures = sum(sum(1 for v in t.values() if v == '❌') for t in tests.values())
             groups.append((package_name, bucket_type, tests, total_failures))
 
     # Sort groups: total_failures descending, then package alpha, then bucket type alpha
@@ -307,26 +266,27 @@ def generate_test_level_report(results, files_processed):
             print("=" * 115)
             
             stats = []
-            for test_name, counts in tests.items():
-                passed = counts['passed']
-                failed = counts['failed']
-                skipped = counts['skipped']
+            for test_name, attempts in tests.items():
+                passed = sum(1 for v in attempts.values() if v == '✅')
+                failed = sum(1 for v in attempts.values() if v == '❌')
+                skipped = sum(1 for v in attempts.values() if v == '⚪')
                 
-                total_exec = passed + failed + skipped
+                total_exec = len(attempts)
                 
+                # Construct status string by sorting attempts
+                sorted_atts = [attempts[k] for k in sorted(attempts.keys())]
+                status_label = "".join(sorted_atts)
+                
+                # For sorting by status severity
                 if failed > 0 and passed == 0:
                     status_val = 1
-                    status_label = "FAILED ❌"
                 elif failed > 0 and passed > 0:
                     status_val = 2
-                    status_label = "FLAKY ⚠️"
                 elif passed > 0:
                     status_val = 3
-                    status_label = "PASSED ✅"
                 else:
                     status_val = 4
-                    status_label = "SKIPPED"
-                
+                    
                 stats.append({
                     'test': test_name,
                     'total_exec': total_exec,
@@ -342,22 +302,27 @@ def generate_test_level_report(results, files_processed):
             
             # Dynamically calculate column width for test names
             max_name_len = max([len(s['test']) for s in stats] + [18])
-            header = f"| {'Specific Test Name':<{max_name_len}} | {'Total':<7} | {'Passed':<6} | {'Failed':<8} | {'Skipped':<7} | {'Status':<12} |"
-            print("-" * len(header))
+            
+            # Status column width should be at least 12 or max status length (emojis take 2 spaces)
+            max_status_width = max([get_display_width(s['status_label']) for s in stats] + [12])
+            
+            header = f"| {'Specific Test Name':<{max_name_len}} | {'Total':<7} | {'Passed':<6} | {'Failed':<8} | {'Skipped':<7} | {pad_string('Status', max_status_width)} |"
+            print("-" * get_display_width(header))
             print(header)
-            print("-" * len(header))
+            print("-" * get_display_width(header))
             
             for s in stats:
-                row = f"| {s['test']:<{max_name_len}} | {s['total_exec']:<7} | {s['passed']:<6} | {s['failed']:<8} | {s['skipped']:<7} | {s['status_label']:<12} |"
+                # pad_string is needed for status_label because it contains emojis!
+                row = f"| {s['test']:<{max_name_len}} | {s['total_exec']:<7} | {s['passed']:<6} | {s['failed']:<8} | {s['skipped']:<7} | {pad_string(s['status_label'], max_status_width)} |"
                 print(row)
                 
-            print("-" * len(header))
+            print("-" * get_display_width(header))
 # ==============================================================================
 # 4. MATRIX AND FAILURE REPORTING
 # ==============================================================================
 
 def generate_matrix_report(results, vm_name_prefix):
-    """Prints a matrix view of results per VM and Package."""
+    """Prints a matrix view of results per VM and Package, grouped by OS."""
     print("\n" + "=" * 80)
     print(" GCSFUSE E2E MATRIX SUMMARY ".center(80, "="))
     print("=" * 80)
@@ -380,65 +345,69 @@ def generate_matrix_report(results, vm_name_prefix):
             print("No packages found.")
             continue
             
-        # Shorten VM names for display
-        display_vms = []
+        # Group VMs by OS type
+        os_groups = defaultdict(list)
+        
         for vm in all_vms:
+            # Shorten VM name first
             if vm.startswith(vm_name_prefix):
                 d_vm = vm[len(vm_name_prefix):]
                 if d_vm.startswith("-"):
                     d_vm = d_vm[1:]
-                display_vms.append(d_vm)
             else:
-                display_vms.append(vm)
-        
-        # Calculate width for shortened VM name
-        max_vm_len = max([get_display_width(vm) for vm in display_vms] + [15])
-        
-        # Limit package names to 15 chars for vertical display
-        limit = 15
-        pkg_headers = [pkg[:limit] for pkg in all_packages]
-        pkg_headers_padded = [f"{pkg:<{limit}}" for pkg in pkg_headers]
-        
-        # Build vertical headers
-        header_lines = []
-        for row_idx in range(limit):
-            if row_idx == limit - 1:
-                parts = [f"{'VM Name':<{max_vm_len}}"]
-            else:
-                parts = [f"{' ':<{max_vm_len}}"]
+                d_vm = vm
                 
-            for pkg in pkg_headers_padded:
-                parts.append(f"{pkg[row_idx]:^6}")
-            header_lines.append("| " + " | ".join(parts) + " |")
+            parts = d_vm.split('-')
+            os_group = parts[0]
+            vm_version = d_vm
             
-        header_display_width = get_display_width(header_lines[0])
-        
-        print("-" * header_display_width)
-        for line in header_lines:
-            print(line)
-        print("-" * header_display_width)
-        
-        for i, vm in enumerate(all_vms):
-            display_vm = display_vms[i]
-            row_parts = [pad_string(display_vm, max_vm_len)]
+            os_groups[os_group].append((vm, vm_version))
             
+        # Print a table for each OS group
+        for os_group, vm_list in sorted(os_groups.items()):
+            print(f"\n[OS: {os_group.upper()}]")
+            
+            # Sort VM list by version suffix
+            vm_list.sort(key=lambda x: x[1])
+            
+            # Column headers are the version suffixes
+            col_headers = [v[1] for v in vm_list]
+            
+            # Determine column widths
+            # Width must be at least 6 (for 3 emojis) or header length
+            col_widths = [max(6, len(h)) for h in col_headers]
+            
+            # Package name column width
+            max_pkg_len = max([len(pkg) for pkg in all_packages] + [12])
+            
+            # Build header line
+            header_parts = [f"{'Package Name':<{max_pkg_len}}"]
+            for idx, h in enumerate(col_headers):
+                header_parts.append(f"{h:^{col_widths[idx]}}")
+            
+            header = "| " + " | ".join(header_parts) + " |"
+            print("-" * len(header))
+            print(header)
+            print("-" * len(header))
+            
+            # Print rows (one for each package)
             for pkg in all_packages:
-                attempts = vms[vm].get(pkg, {})
-                if not attempts:
-                    status_str = "⚪"
-                else:
-                    # Sort attempts by key
-                    sorted_attempts = [attempts[k] for k in sorted(attempts.keys())]
-                    # Take at most last 3
-                    last_attempts = sorted_attempts[-3:]
-                    status_str = "".join(last_attempts)
+                row_parts = [f"{pkg:<{max_pkg_len}}"]
+                for idx, (orig_vm, _) in enumerate(vm_list):
+                    attempts = vms[orig_vm].get(pkg, {})
+                    if not attempts:
+                        status_str = "⚪"
+                    else:
+                        sorted_attempts = [attempts[k] for k in sorted(attempts.keys())]
+                        last_attempts = sorted_attempts[-3:]
+                        status_str = "".join(last_attempts)
+                        
+                    row_parts.append(pad_string(status_str, col_widths[idx], align='center'))
                     
-                row_parts.append(pad_string(status_str, 6))
+                row = "| " + " | ".join(row_parts) + " |"
+                print(row)
                 
-            row = "| " + " | ".join(row_parts) + " |"
-            print(row)
-            
-        print("-" * header_display_width)
+            print("-" * len(header))
 
 
 def generate_consolidated_failures_table(failures, bucket_name, release_version, vm_name_prefix):
@@ -461,8 +430,12 @@ def generate_consolidated_failures_table(failures, bucket_name, release_version,
         else:
             display_vm = vm
             
-        link = f"https://console.cloud.google.com/storage/browser/{bucket_name}/{release_version}/{f['vm']}/failed-package-gcsfuse-logs"
+        link = f"https://pantheon.corp.google.com/storage/browser/{bucket_name}/{release_version}/{f['vm']}/failed-package-gcsfuse-logs"
         
+        test_logs_link = ""
+        if f.get('e2e_run_folder'):
+            test_logs_link = f"https://pantheon.corp.google.com/storage/browser/_details/{bucket_name}/{release_version}/{f['vm']}/{f['e2e_run_folder']}/failed_package_logs/{f['bucket'].lower()}/{f['pkg']}.txt"
+            
         test_name = f['test']
         if len(test_name) > 35:
             test_name = test_name[:32] + "..."
@@ -472,7 +445,8 @@ def generate_consolidated_failures_table(failures, bucket_name, release_version,
             'vm': display_vm,
             'pkg': f['pkg'],
             'test': test_name,
-            'link': link
+            'link': link,
+            'test_logs': test_logs_link
         })
         
     formatted_failures.sort(key=lambda x: (x['vm'], x['pkg'], x['test']))
@@ -481,16 +455,17 @@ def generate_consolidated_failures_table(failures, bucket_name, release_version,
     w_vm = max([len(f['vm']) for f in formatted_failures] + [15])
     w_pkg = max([len(f['pkg']) for f in formatted_failures] + [20])
     w_test = max([len(f['test']) for f in formatted_failures] + [35])
-    w_link = max([len(f['link']) for f in formatted_failures] + [50])
+    w_link = max([len(f['link']) for f in formatted_failures] + [21]) # "gcsfuse logs location" len is 21
+    w_test_logs = max([len(f['test_logs']) for f in formatted_failures] + [9]) # "test logs" len is 9
     
-    header = f"| {'Bucket':<{w_bucket}} | {'VM':<{w_vm}} | {'Package':<{w_pkg}} | {'Test':<{w_test}} | {'Logs Link':<{w_link}} |"
+    header = f"| {'Bucket':<{w_bucket}} | {'VM':<{w_vm}} | {'Package':<{w_pkg}} | {'Test':<{w_test}} | {'test logs':<{w_test_logs}} | {'gcsfuse logs location':<{w_link}} |"
     
     print("-" * len(header))
     print(header)
     print("-" * len(header))
     
     for f in formatted_failures:
-        row = f"| {f['bucket']:<{w_bucket}} | {f['vm']:<{w_vm}} | {f['pkg']:<{w_pkg}} | {f['test']:<{w_test}} | {f['link']:<{w_link}} |"
+        row = f"| {f['bucket']:<{w_bucket}} | {f['vm']:<{w_vm}} | {f['pkg']:<{w_pkg}} | {f['test']:<{w_test}} | {f['test_logs']:<{w_test_logs}} | {f['link']:<{w_link}} |"
         print(row)
         
     print("-" * len(header))
@@ -506,6 +481,7 @@ def main():
     parser.add_argument("--release-bucket-name", default="gcsfuse-release-packages", help="Release bucket name")
     parser.add_argument("--vm-name-prefix", required=True, help="VM name prefix (e.g., mky-release-test)")
     parser.add_argument("--output-file", help="Path to save final output (optional, defaults to stdout)")
+    parser.add_argument("--cache-dir", help="Directory to cache downloaded logs (optional)")
     args = parser.parse_args()
 
     # Redirect stdout if output file is specified
@@ -516,9 +492,25 @@ def main():
             print(f"Error opening output file {args.output_file}: {e}", file=sys.stderr)
 
     # Determine paths
-    with tempfile.TemporaryDirectory(prefix="gcsfuse_output_") as output_dir:
-        # Step 1: Sync
-        sync_success = sync_logs(args.release_bucket_name, args.release_version, args.vm_name_prefix, output_dir)
+    with contextlib.ExitStack() as stack:
+        output_dir = None
+        sync_success = False
+        
+        if args.cache_dir:
+            cache_path = Path(args.cache_dir)
+            if cache_path.exists() and any(cache_path.iterdir()):
+                print(f"Using cached logs from {args.cache_dir}")
+                output_dir = args.cache_dir
+                sync_success = True
+            else:
+                print(f"Cache directory {args.cache_dir} is empty or missing. Downloading...")
+                cache_path.mkdir(parents=True, exist_ok=True)
+                output_dir = args.cache_dir
+                sync_success = sync_logs(args.release_bucket_name, args.release_version, args.vm_name_prefix, output_dir)
+                
+        if not output_dir:
+            output_dir = stack.enter_context(tempfile.TemporaryDirectory(prefix="gcsfuse_output_"))
+            sync_success = sync_logs(args.release_bucket_name, args.release_version, args.vm_name_prefix, output_dir)
 
         if not sync_success:
             print("\n" + "!" * 80)
@@ -529,23 +521,7 @@ def main():
         # Step 2: Runtime Stats Analysis
         results_rt, count_rt = analyze_runtime_stats(output_dir)
         
-        # Aggregate results for the old runtime report to avoid breaking it
-        from collections import defaultdict
-        aggregated_rt = defaultdict(lambda: defaultdict(lambda: {'passed': 0, 'failed': 0, 'flaky': 0}))
-        for btype, vms in results_rt.items():
-            for vm, pkgs in vms.items():
-                for pkg, attempts in pkgs.items():
-                    sorted_atts = sorted(attempts.keys())
-                    last_status = attempts[sorted_atts[-1]]
-                    if last_status == '✅':
-                        if len(sorted_atts) > 1:
-                            aggregated_rt[btype][pkg]['flaky'] += 1
-                        else:
-                            aggregated_rt[btype][pkg]['passed'] += 1
-                    else:
-                        aggregated_rt[btype][pkg]['failed'] += 1
-                        
-        generate_runtime_report(aggregated_rt, count_rt)
+
 
         # Step 3: Matrix Summary
         generate_matrix_report(results_rt, args.vm_name_prefix)


### PR DESCRIPTION
# GitHub PR Description

**Title:** Refactor release_analyser: Add matrix view, consolidated failure links, and attempt tracking

## Overview
This PR enhances the `release_analyser.py` script by introducing a matrix summary view of test results, a consolidated failures table with direct links to GCS logs, and better tracking for individual test attempts. It also improves visual alignment for reports containing emojis and adds local log caching capabilities.

## Key Changes
*   **Matrix Summary Report:** Added `generate_matrix_report` to print a matrix view of results per VM and Package, grouped by OS.
*   **Consolidated Failures Table:** Added `generate_consolidated_failures_table` to output a centralized table of all failures, complete with direct HTTPS links to the `failed-package-gcsfuse-logs` and `test logs` in Google Cloud Storage.
*   **Test Attempt Tracking:** Refactored log parsing logic in `analyze_runtime_stats` and `analyze_test_level_logs` to track individual test attempts (e.g., `results[btype][vm_name][pkg][attempt] = status_emoji`) rather than just aggregating pass/fail counts.
*   **Improved Formatting & Emoji Support:** Introduced `get_display_width` and `pad_string` functions to properly align table columns when common emojis (`✅`, `❌`, `⚠️`, `⚪`) are used, counting them as width 2.
*   **Local Caching:** Added a `--cache-dir` argument to allow caching downloaded logs, avoiding redundant GCS downloads across multiple script executions.
*   **Cleanup:** Removed legacy reporting functions like `generate_runtime_report` in favor of the new comprehensive outputs.

## Testing
- Verified table alignments with emoji statuses.
- Verified GCS failure links point to the correct buckets.
