### PR TITLE
Centralize BigQuery table truncation in benchmark runner

### DIFF
--- a/npi/fio/fio_benchmark_runner.py
+++ b/npi/fio/fio_benchmark_runner.py
@@ -190,6 +190,35 @@ def print_summary(all_results, summary_file=None):
             logging.error(f"Failed to write summary to {summary_file}: {e}")
 
 
+def truncate_bq_table(project_id, dataset_id, table_id):
+    """Erases existing data in the specified BigQuery table."""
+    if not _BQ_SUPPORTED:
+        logging.error(
+            "BigQuery truncation requested, but 'google-cloud-bigquery' is not "
+            "installed. Please run 'pip3 install google-cloud-bigquery'."
+        )
+        return
+
+    try:
+        client = bigquery.Client(project=project_id)
+        full_table_id = f"{project_id}.{dataset_id}.{table_id}"
+        
+        # Check if table exists before truncating
+        try:
+            client.get_table(full_table_id)
+        except exceptions.NotFound:
+            logging.info(f"Table {full_table_id} not found, skipping truncation.")
+            return
+
+        logging.info(f"--- Erasing data in BigQuery table: {full_table_id} ---")
+        query = f"TRUNCATE TABLE `{full_table_id}`"
+        query_job = client.query(query)
+        query_job.result()  # Wait for the job to complete
+        logging.info(f"Successfully truncated table {full_table_id}")
+    except Exception as e:
+        logging.error(f"Failed to truncate BigQuery table: {e}")
+
+
 def upload_results_to_bq(
     project_id, dataset_id, table_id, fio_json_path, iteration,
     gcsfuse_flags, fio_env, cpu_limit_list
@@ -269,6 +298,9 @@ def run_benchmark(
     """Runs the full FIO benchmark suite."""
     os.makedirs(work_dir, exist_ok=True)
     os.makedirs(output_dir, exist_ok=True)
+
+    if project_id and bq_dataset_id and bq_table_id:
+        truncate_bq_table(project_id, bq_dataset_id, bq_table_id)
 
     gcsfuse_bin = "/gcsfuse/gcsfuse"
     if mount_path:

--- a/npi/npi_gke.py
+++ b/npi/npi_gke.py
@@ -17,22 +17,6 @@ import time
 import yaml
 import os
 
-def truncate_bq_table(project_id, dataset_id, table_id):
-    """Erases existing data in the specified BigQuery table."""
-    if not (project_id and dataset_id and table_id):
-        return
-    print(f"--- Erasing data in BigQuery table: {project_id}.{dataset_id}.{table_id} ---")
-    bq_cmd = [
-        "bq", "query", "--use_legacy_sql=false",
-        f"TRUNCATE TABLE `{project_id}.{dataset_id}.{table_id}`"
-    ]
-    try:
-        res = subprocess.run(bq_cmd, capture_output=True, text=True)
-        if res.returncode != 0 and "Not found:" not in res.stderr:
-            print(f"Warning: Failed to truncate BQ table. {res.stderr}")
-    except Exception as e:
-        print(f"Warning: Failed to execute bq command: {e}")
-
 def create_job_spec(job_name, image, args, bucket_name, service_account, extra_flag=None):
     """Creates a Kubernetes Job spec dictionary from the template yaml."""
     script_dir = os.path.dirname(os.path.realpath(__file__))
@@ -67,13 +51,10 @@ def create_job_spec(job_name, image, args, bucket_name, service_account, extra_f
 
 def run_benchmark_job(job_name, image, args_list, project_id, dataset_id, table_id, bucket_name, service_account, timeout="1h", extra_flag=None):
     """Runs a benchmark job on GKE and waits for its completion."""
-    # 1. Truncate BQ Table
-    truncate_bq_table(project_id, dataset_id, table_id)
-
-    # 2. Cleanup any existing job with the same name
+    # 1. Cleanup any existing job with the same name
     subprocess.run(["kubectl", "delete", "job", job_name, "--ignore-not-found=true", "--wait=true"], capture_output=True)
 
-    # 3. Create Job Spec and Apply
+    # 2. Create Job Spec and Apply
     job_spec = create_job_spec(job_name, image, args_list, bucket_name, service_account, extra_flag)
     yaml_data = yaml.dump(job_spec)
 


### PR DESCRIPTION
Moved the logic to truncate the BigQuery table from the GKE orchestration script (`npi_gke.py`) to the core FIO benchmark runner (`fio_benchmark_runner.py`). This ensures that the docker image is responsible for both truncating the table and uploading the results, centralizing the BigQuery interactions.