### PR TITLE
Explicitly provide HTTP/1 as the client protocol

### DIFF
--- a/npi/npi.py
+++ b/npi/npi.py
@@ -223,8 +223,8 @@ class BenchmarkFactory:
             if cpu_list:
                 numa_name = f"numa{node_id}"
                 # For NUMA nodes, create 4 configs: http1/grpc with and without binding fio
-                configs[f"http1_{numa_name}_fio_notbound"] = {"cpu_list": cpu_list, "bind_fio": False}
-                configs[f"http1_{numa_name}_fio_bound"] = {"cpu_list": cpu_list, "bind_fio": True}
+                configs[f"http1_{numa_name}_fio_notbound"] = {"cpu_list": cpu_list, "bind_fio": False, "--client-protocol=http1"}
+                configs[f"http1_{numa_name}_fio_bound"] = {"cpu_list": cpu_list, "bind_fio": True, "--client-protocol=http1"}
                 configs[f"grpc_{numa_name}_fio_notbound"] = {"cpu_list": cpu_list, "gcsfuse_flags": "--client-protocol=grpc", "bind_fio": False}
                 configs[f"grpc_{numa_name}_fio_bound"] = {"cpu_list": cpu_list, "gcsfuse_flags": "--client-protocol=grpc", "bind_fio": True}
 

--- a/npi/npi.py
+++ b/npi/npi.py
@@ -223,8 +223,8 @@ class BenchmarkFactory:
             if cpu_list:
                 numa_name = f"numa{node_id}"
                 # For NUMA nodes, create 4 configs: http1/grpc with and without binding fio
-                configs[f"http1_{numa_name}_fio_notbound"] = {"cpu_list": cpu_list, "bind_fio": False, "--client-protocol=http1"}
-                configs[f"http1_{numa_name}_fio_bound"] = {"cpu_list": cpu_list, "bind_fio": True, "--client-protocol=http1"}
+                configs[f"http1_{numa_name}_fio_notbound"] = {"cpu_list": cpu_list, "bind_fio": False, "gcsfuse_flags": "--client-protocol=http1"}
+                configs[f"http1_{numa_name}_fio_bound"] = {"cpu_list": cpu_list, "bind_fio": True, "gcsfuse_flags": "--client-protocol=http1"}
                 configs[f"grpc_{numa_name}_fio_notbound"] = {"cpu_list": cpu_list, "gcsfuse_flags": "--client-protocol=grpc", "bind_fio": False}
                 configs[f"grpc_{numa_name}_fio_bound"] = {"cpu_list": cpu_list, "gcsfuse_flags": "--client-protocol=grpc", "bind_fio": True}
 

--- a/npi/npi.py
+++ b/npi/npi.py
@@ -223,8 +223,8 @@ class BenchmarkFactory:
             if cpu_list:
                 numa_name = f"numa{node_id}"
                 # For NUMA nodes, create 4 configs: http1/grpc with and without binding fio
-                configs[f"http1_{numa_name}_fio_notbound"] = {"cpu_list": cpu_list, "bind_fio": False, "gcsfuse_flags": "--client-protocol=http1"}
-                configs[f"http1_{numa_name}_fio_bound"] = {"cpu_list": cpu_list, "bind_fio": True, "gcsfuse_flags": "--client-protocol=http1"}
+                configs[f"http1_{numa_name}_fio_notbound"] = {"cpu_list": cpu_list, "gcsfuse_flags": "--client-protocol=http1", "bind_fio": False}
+                configs[f"http1_{numa_name}_fio_bound"] = {"cpu_list": cpu_list, "gcsfuse_flags": "--client-protocol=http1", "bind_fio": True}
                 configs[f"grpc_{numa_name}_fio_notbound"] = {"cpu_list": cpu_list, "gcsfuse_flags": "--client-protocol=grpc", "bind_fio": False}
                 configs[f"grpc_{numa_name}_fio_bound"] = {"cpu_list": cpu_list, "gcsfuse_flags": "--client-protocol=grpc", "bind_fio": True}
 

--- a/npi/npi.py
+++ b/npi/npi.py
@@ -213,7 +213,7 @@ class BenchmarkFactory:
 
         # Define test configurations (protocol, cpu pinning, etc.)
         configs = {
-            "http1": {},
+            "http1": {"gcsfuse_flags": "--client-protocol=http1"},
             "grpc": {"gcsfuse_flags": "--client-protocol=grpc"},
         }
 


### PR DESCRIPTION
While currently HTTP/1 is the default, so the NPI benchmarks use HTTP/1 when client-protocol is not specified. However, say in the future gRPC becomes the default, NPI will silently run the HTTP/1 benchmarks with gRPC under the hood which will lead to misleading results. This change fixes that.