### PR TITLE
Fix silent failures in npi test suite run_fio_matrix.py

### DIFF
--- a/npi/fio/run_fio_matrix.py
+++ b/npi/fio/run_fio_matrix.py
@@ -137,6 +137,8 @@ def main():
     bq_client = fio_benchmark_runner.bigquery.Client(project=args.project_id)
     fio_benchmark_runner.truncate_bq_table(bq_client, args.project_id, args.bq_dataset_id, args.bq_table_id)
 
+  has_failures = False
+
   for i, config in enumerate(configs):
     # Create a string representation of the configuration for logging.
     config_str = ", ".join([f"{k}={v}" for k, v in sorted(config.items())])
@@ -174,10 +176,14 @@ def main():
           keep_mount=args.keep_mount)
     except Exception as e:
       logging.error("Benchmark run failed for configuration %s: %s", config, e)
+      has_failures = True
       # Continue to the next configuration
       continue
 
   logging.info("--- All benchmark matrix runs complete. ---")
+
+  if has_failures:
+    sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
Fixes a silent failure in `run_fio_matrix.py` where benchmark errors were caught and ignored, causing Kubernetes Jobs to incorrectly report as `Complete`.

This issue was originally surfaced when running the NPI test suite with `--is-rapid-bucket`. The `write_grpc` benchmarks were correctly scheduled (as seen via `--dry-run`), but appeared to be completely "skipped" during the actual run because the underlying FIO write failures were swallowed by the script.

### Changes
* Added a `has_failures` flag to track errors across loop iterations.
* If any FIO configuration fails, the script will now log the error, continue the remaining tests, and ultimately exit with code `1`.
* This ensures that orchestration tools (e.g., `npi_gke.py`) accurately recognize failed benchmarks.