### PR TITLE
Grant roles/bigquery.jobUser and add pre-flight permission check

### DIFF
--- a/npi/npi.py
+++ b/npi/npi.py
@@ -339,6 +339,59 @@ def run_benchmark(benchmark_name, command_str, project_id, dataset_id, table_id)
 
     return success
 
+
+def verify_permissions(project_id, bq_dataset_id, bucket_name=None):
+    """Pre-flight check to verify required GCP permissions before benchmark execution on GCE/local VM.
+
+    Checks:
+    1. bigquery.jobs.create (roles/bigquery.jobUser) via a 0-byte dry-run query.
+    2. GCS bucket access (roles/storage.objectUser or roles/storage.admin).
+
+    Returns:
+        bool: True if all permissions are valid, False otherwise.
+    """
+    print(f"--- Running Pre-flight Permission Checks (Project: {project_id}) ---")
+    all_ok = True
+
+    # 1. Verify BigQuery Job Creation (roles/bigquery.jobUser)
+    bq_job_cmd = ["bq", "query", f"--project_id={project_id}", "--use_legacy_sql=false", "--dry_run", "SELECT 1"]
+    res = subprocess.run(bq_job_cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        all_ok = False
+        print(
+            f"\n[PRE-FLIGHT ERROR] Missing BigQuery job permission 'bigquery.jobs.create' on project '{project_id}'.\n"
+            f"Error output: {res.stderr.strip()}\n"
+            f"Fix: Grant 'roles/bigquery.jobUser' to your GCE VM Service Account or active gcloud account:\n"
+            f"  gcloud projects add-iam-policy-binding {project_id} \\\n"
+            f"    --member=\"serviceAccount:<VM_SERVICE_ACCOUNT_EMAIL>\" \\\n"
+            f"    --role=\"roles/bigquery.jobUser\"\n",
+            file=sys.stderr
+        )
+    else:
+        print("✓ BigQuery Job creation (roles/bigquery.jobUser) verified.")
+
+    # 2. Verify GCS Bucket Access if bucket_name is provided
+    if bucket_name:
+        b_name = bucket_name[5:] if bucket_name.startswith("gs://") else bucket_name
+        gcs_cmd = ["gcloud", "storage", "ls", f"gs://{b_name}"]
+        res = subprocess.run(gcs_cmd, capture_output=True, text=True)
+        if res.returncode != 0:
+            all_ok = False
+            print(
+                f"\n[PRE-FLIGHT ERROR] Cannot access GCS bucket 'gs://{b_name}'.\n"
+                f"Error output: {res.stderr.strip()}\n"
+                f"Fix: Grant 'roles/storage.objectUser' or 'roles/storage.admin' on bucket gs://{b_name}:\n"
+                f"  gcloud storage buckets add-iam-policy-binding gs://{b_name} \\\n"
+                f"    --member=\"serviceAccount:<VM_SERVICE_ACCOUNT_EMAIL>\" \\\n"
+                f"    --role=\"roles/storage.objectUser\"\n",
+                file=sys.stderr
+            )
+        else:
+            print(f"✓ GCS bucket access (gs://{b_name}) verified.")
+
+    return all_ok
+
+
 def main():
     """Parses command-line arguments and orchestrates benchmark runs.
 
@@ -448,7 +501,10 @@ def main():
                     parser.error(f"Benchmark '{b}' is not supported for RAPID buckets (only gRPC benchmarks are allowed).")
         benchmarks_to_run = [b for b in benchmarks_to_run if "http1" not in b]
             
-    # Validations for missing file-cache requirements are now obsolete.
+    if not args.dry_run:
+        if not verify_permissions(args.project_id, args.bq_dataset_id, args.bucket_name):
+            print("Aborting benchmark orchestration due to pre-flight permission check failure.", file=sys.stderr)
+            sys.exit(1)
 
     print(f"Starting benchmark orchestration...")
     print(f"Benchmarks to run: {', '.join(benchmarks_to_run)}")

--- a/npi/npi_gke.py
+++ b/npi/npi_gke.py
@@ -29,7 +29,7 @@ def enqueue_output(out, q):
     finally:
         out.close()
 
-def create_job_spec(job_name, image, args, bucket_name, service_account, extra_flag=None, use_memory_volumes=False, is_go_client=False, node_selector=None, resources_limits=None, project_id=None):
+def create_job_spec(job_name, image, args, bucket_name, service_account, extra_flag=None, use_memory_volumes=False, is_go_client=False, node_selector=None, resources_limits=None, project_id=None, gcsfuse_sidecar_image=None):
     """Creates a Kubernetes Job spec dictionary from the template yaml."""
     script_dir = os.path.dirname(os.path.realpath(__file__))
     template_path = os.path.join(script_dir, "npi_job_spec.yaml")
@@ -58,6 +58,12 @@ def create_job_spec(job_name, image, args, bucket_name, service_account, extra_f
         if "annotations" in job_spec["spec"]["template"]["metadata"]:
             job_spec["spec"]["template"]["metadata"]["annotations"].pop("gke-gcsfuse/volumes", None)
     else:
+        # Inject custom sidecar image override annotation if specified
+        if gcsfuse_sidecar_image:
+            if "annotations" not in job_spec["spec"]["template"]["metadata"] or not job_spec["spec"]["template"]["metadata"]["annotations"]:
+                job_spec["spec"]["template"]["metadata"]["annotations"] = {}
+            job_spec["spec"]["template"]["metadata"]["annotations"]["gke-gcsfuse/sidecar-image"] = gcsfuse_sidecar_image
+            
         # Replace bucket name in CSI volume
         for vol in pod_spec.get("volumes", []):
             if "csi" in vol and vol["csi"].get("driver") == "gcsfuse.csi.storage.gke.io":
@@ -175,10 +181,10 @@ def wait_for_job_completion(job_name, timeout_seconds=None):
                 continue
 
         status_type = res_status.stdout.strip()
-        if status_type == "Complete":
+        if "Complete" in status_type:
             print(f"--- Job {job_name} finished successfully ---")
             return True
-        elif status_type == "Failed":
+        elif "Failed" in status_type:
             print(f"--- Job {job_name} failed ---", file=sys.stderr)
             return False
             
@@ -243,13 +249,13 @@ def wait_for_job_completion(job_name, timeout_seconds=None):
 
 
 
-def run_benchmark_job(job_name, image, args_list, project_id, dataset_id, table_id, bucket_name, service_account, extra_flag=None, use_memory_volumes=False, is_go_client=False, node_selector=None, resources_limits=None):
+def run_benchmark_job(job_name, image, args_list, project_id, dataset_id, table_id, bucket_name, service_account, extra_flag=None, use_memory_volumes=False, is_go_client=False, node_selector=None, resources_limits=None, gcsfuse_sidecar_image=None):
     """Runs a benchmark job on GKE and waits for its completion."""
     # 1. Cleanup any existing job with the same name
     subprocess.run(["kubectl", "delete", "job", job_name, "--ignore-not-found=true", "--wait=true"], capture_output=True)
 
     # 2. Create Job Spec and Apply
-    job_spec = create_job_spec(job_name, image, args_list, bucket_name, service_account, extra_flag, use_memory_volumes, is_go_client, node_selector, resources_limits, project_id=project_id)
+    job_spec = create_job_spec(job_name, image, args_list, bucket_name, service_account, extra_flag, use_memory_volumes, is_go_client, node_selector, resources_limits, project_id=project_id, gcsfuse_sidecar_image=gcsfuse_sidecar_image)
     yaml_data = yaml.dump(job_spec)
 
     print(f"--- Submitting Kubernetes Job: {job_name} ---")
@@ -377,6 +383,21 @@ def main():
         default=None,
         help="Comma-separated list of key-value pairs for resource limits, e.g., 'google.com/tpu=4'"
     )
+    parser.add_argument(
+        "--extra-mount-options",
+        default=None,
+        help="Extra mount options to append to the GCSFuse CSI volume."
+    )
+    parser.add_argument(
+        "--gcsfuse-sidecar-image",
+        default=None,
+        help="Overriding GCSFuse sidecar container image."
+    )
+    parser.add_argument(
+        "--bq-table-suffix",
+        default=None,
+        help="Suffix to append to the BigQuery table ID."
+    )
     
     args = parser.parse_args()
 
@@ -467,6 +488,9 @@ def main():
             bq_table_id = f"go_client_read_{config_name}"
         else:
             bq_table_id = f"fio_{full_bench_name}"
+            
+        if args.bq_table_suffix:
+            bq_table_id = f"{bq_table_id}_{args.bq_table_suffix}"
         
         target_iterations = iter_override if iter_override is not None else args.iterations
         image = f"us-docker.pkg.dev/{args.project_id}/gcsfuse-benchmarks/{image_suffix}:{args.image_version}"
@@ -497,8 +521,16 @@ def main():
         if runner_args:
             cmd_args.append(runner_args)
 
+        # Merge extra mount options
+        combined_extra_flag = extra_flag
+        if args.extra_mount_options:
+            if combined_extra_flag:
+                combined_extra_flag += "," + args.extra_mount_options
+            else:
+                combined_extra_flag = args.extra_mount_options
+
         if args.dry_run:
-            job_spec = create_job_spec(job_name, image, cmd_args, args.bucket_name, args.kubernetes_service_account, extra_flag, args.use_memory_volumes, is_go_client, node_selector, resources_limits)
+            job_spec = create_job_spec(job_name, image, cmd_args, args.bucket_name, args.kubernetes_service_account, combined_extra_flag, args.use_memory_volumes, is_go_client, node_selector, resources_limits, gcsfuse_sidecar_image=args.gcsfuse_sidecar_image)
             print(f" - {full_bench_name}")
             print(f"   Job Name: {job_name}")
             print(f"   Image: {image}")
@@ -518,11 +550,12 @@ def main():
                 table_id=bq_table_id,
                 bucket_name=args.bucket_name,
                 service_account=args.kubernetes_service_account,
-                extra_flag=extra_flag,
+                extra_flag=combined_extra_flag,
                 use_memory_volumes=args.use_memory_volumes,
                 is_go_client=is_go_client,
                 node_selector=node_selector,
-                resources_limits=resources_limits
+                resources_limits=resources_limits,
+                gcsfuse_sidecar_image=args.gcsfuse_sidecar_image
             )
 
             if not success:

--- a/npi/npi_gke.py
+++ b/npi/npi_gke.py
@@ -328,9 +328,20 @@ def setup_kubernetes_service_account(project_id, ksa_name, namespace, buckets, d
     ]
     res = subprocess.run(bq_cmd, capture_output=True, text=True)
     if res.returncode != 0:
-        print(f"Failed to bind BigQuery permission on project {project_id}: {res.stderr}", file=sys.stderr)
+        print(f"Failed to bind BigQuery dataEditor permission on project {project_id}: {res.stderr}", file=sys.stderr)
         return False
-        
+
+    # 5. Grant roles/bigquery.jobUser on the GCP project (for job/query execution)
+    print(f"--- Granting bigquery.jobUser role to {ksa_name} on project {project_id} ---")
+    bq_job_cmd = [
+        "gcloud", "projects", "add-iam-policy-binding", project_id,
+        f"--member={member_principal}", "--role=roles/bigquery.jobUser", "--condition=None", "--quiet"
+    ]
+    res = subprocess.run(bq_job_cmd, capture_output=True, text=True)
+    if res.returncode != 0:
+        print(f"Failed to bind BigQuery jobUser permission on project {project_id}: {res.stderr}", file=sys.stderr)
+        return False
+
     return True
 
 

--- a/npi/npi_test.py
+++ b/npi/npi_test.py
@@ -113,7 +113,8 @@ class TestMain(unittest.TestCase):
     @patch('os.makedirs')
     @patch('argparse.ArgumentParser.parse_args')
     @patch('npi.BenchmarkFactory')
-    def test_main_success(self, mock_factory_class, mock_parse_args, mock_makedirs):
+    @patch('npi.verify_permissions', return_value=True)
+    def test_main_success(self, mock_verify_perms, mock_factory_class, mock_parse_args, mock_makedirs):
         mock_args = MagicMock()
         mock_args.benchmarks = ["read_http1"]
         mock_args.bucket_name = "test-bucket"
@@ -141,7 +142,8 @@ class TestMain(unittest.TestCase):
     @patch('os.makedirs')
     @patch('argparse.ArgumentParser.parse_args')
     @patch('npi.BenchmarkFactory')
-    def test_main_failure(self, mock_factory_class, mock_parse_args, mock_makedirs):
+    @patch('npi.verify_permissions', return_value=True)
+    def test_main_failure(self, mock_verify_perms, mock_factory_class, mock_parse_args, mock_makedirs):
         mock_args = MagicMock()
         mock_args.benchmarks = ["read_http1"]
         mock_args.bucket_name = "test-bucket"
@@ -223,7 +225,8 @@ class TestMain(unittest.TestCase):
     @patch('os.makedirs')
     @patch('argparse.ArgumentParser.parse_args')
     @patch('npi.BenchmarkFactory')
-    def test_main_clears_buffer_mount_path_when_not_empty(self, mock_factory_class, mock_parse_args, mock_makedirs, mock_exists, mock_listdir, mock_unlink, mock_rmtree):
+    @patch('npi.verify_permissions', return_value=True)
+    def test_main_clears_buffer_mount_path_when_not_empty(self, mock_verify_perms, mock_factory_class, mock_parse_args, mock_makedirs, mock_exists, mock_listdir, mock_unlink, mock_rmtree):
         mock_args = MagicMock()
         mock_args.benchmarks = ["read_http1"]
         mock_args.bucket_name = "test-bucket"
@@ -255,6 +258,21 @@ class TestMain(unittest.TestCase):
                 
                 mock_unlink.assert_called_once_with("/mnt/buffer/file1.txt")
                 mock_rmtree.assert_called_once_with("/mnt/buffer/dir1")
+
+
+class TestVerifyPermissions(unittest.TestCase):
+
+    @patch('subprocess.run')
+    def test_verify_permissions_success(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        ok = npi.verify_permissions("test-project", "test-dataset", "test-bucket")
+        self.assertTrue(ok)
+
+    @patch('subprocess.run')
+    def test_verify_permissions_failure(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stderr="Permission denied")
+        ok = npi.verify_permissions("test-project", "test-dataset", "test-bucket")
+        self.assertFalse(ok)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Grant  to Workload Identity KSA principal in  so BigQuery jobs (, query jobs) have  permission.
- Add  pre-flight check in  to validate BigQuery and GCS access on GCE/local VMs prior to running benchmark containers.