### PR TITLE
fix(agents): correct skills path references and index consistency

### DIFF
--- a/npi/.agents/agents/gcsfuse-npi-runner.md
+++ b/npi/.agents/agents/gcsfuse-npi-runner.md
@@ -13,7 +13,7 @@ You are a specialized GCSFuse NPI Runner agent. Your mission is to execute the c
 ## Workflow Sequence
 You must run the workflow stages strictly in the following sequential order:
 1.  **SSH Connection Prep**: Clean up any stale sockets and establish persistent multiplexed SSH connections.
-2.  **Conformance Testing**: Clone the GCSFuse repo and execute the integration test suite on the target VM, producing `conformance_results.json`.
+2.  **Conformance Testing**: Clone the GCSFuse repo and execute the integration test suite on the target VM, producing `conformance_results_<TARGET_NAME>.json`.
 3.  **Performance Benchmarking**: Build/push benchmarking images, run the benchmark suite via `npi_orchestrator.py`, and upload metrics to BigQuery.
 4.  **Analysis**: Extract metrics, compare throughput/latency against baselines, and compile `npi_validation_report.md`.
 5.  **Remediation**: Analyze conformance failures and configuration mismatches, producing `npi_remediation_plan.md`.
@@ -49,9 +49,10 @@ If the target configuration is missing or ambiguous in the request, ask the user
 
 ## Skills & Methods
 Refer to the modular skills in the workspace for step-by-step guidance:
-- SSH Connection: `.gemini/skills/ssh-connection-management/SKILL.md`
-- Conformance: `.gemini/skills/conformance-testing/SKILL.md`
-- Build & Setup: `.gemini/skills/benchmark-build-setup/SKILL.md`
-- Benchmarking: `.gemini/skills/benchmark-suite-execution/SKILL.md`
-- Analysis: `.gemini/skills/analysis-report-generation/SKILL.md`
-- Remediation: `.gemini/skills/remediation-advisor/SKILL.md`
+- Index: `.agents/skills/run-gcsfuse-npi/SKILL.md`
+- SSH Connection: `.agents/skills/ssh-connection-management/SKILL.md`
+- Conformance: `.agents/skills/conformance-testing/SKILL.md`
+- Build & Setup: `.agents/skills/benchmark-build-setup/SKILL.md`
+- Benchmarking: `.agents/skills/benchmark-suite-execution/SKILL.md`
+- Analysis: `.agents/skills/analysis-report-generation/SKILL.md`
+- Remediation: `.agents/skills/remediation-advisor/SKILL.md`

--- a/npi/.agents/skills/run-gcsfuse-npi/SKILL.md
+++ b/npi/.agents/skills/run-gcsfuse-npi/SKILL.md
@@ -9,8 +9,8 @@ This index references the modularized, agent-specific skills for running GCSFuse
 
 ## Modular Skills Index
 
-1.  **[Conformance Testing](../conformance-testing/SKILL.md)**: Guides on cloning the official GCSFuse repository, executing integration and conformance tests on target GCE VMs, and generating a structured `conformance_results_<TARGET_NAME>.json`.
-2.  **[SSH Connection Management](../ssh-connection-management/SKILL.md)**: Focuses on persistent SSH socket multiplexing, checking and cleaning up stale socket files, establishing the master SSH connection, verifying status, and handling target-specific socket paths.
+1.  **[SSH Connection Management](../ssh-connection-management/SKILL.md)**: Focuses on persistent SSH socket multiplexing, checking and cleaning up stale socket files, establishing the master SSH connection, verifying status, and handling target-specific socket paths.
+2.  **[Conformance Testing](../conformance-testing/SKILL.md)**: Guides on cloning the official GCSFuse repository, executing integration and conformance tests on target GCE VMs, and generating a structured `conformance_results_<TARGET_NAME>.json`.
 3.  **[Benchmark Build & Setup](../benchmark-build-setup/SKILL.md)**: Focuses on checking out the GCSFuse repository, building Docker/GKE benchmark images locally or on the target, configuring registry access, pushing built images to Artifact Registry, and verifying image availability.
 4.  **[Benchmark Suite Execution](../benchmark-suite-execution/SKILL.md)**: Focuses on executing benchmarking workflows (GCE VM FIO tests, GKE container tests) using `npi_orchestrator.py`, parameterizing VM/cluster names dynamically from configured inputs like `targets.json`, handling parameters, verifying BQ table exports, and monitoring job states.
 5.  **[Analysis & Report Generation](../analysis-report-generation/SKILL.md)**: Focuses on querying BigQuery tables for throughput/latency metrics, comparing results against baseline runs, and generating a standardized `npi_validation_report.md`.


### PR DESCRIPTION
### Summary of Changes

1. **Fixed Skill References in Agent Definition ()**:
   - Updated outdated `.gemini/skills/` path references to `.agents/skills/`.
   - Added `run-gcsfuse-npi` index skill to the Skills & Methods list.
   - Updated `conformance_results.json` to target-specific output naming convention `conformance_results_<TARGET_NAME>.json`.

2. **Ensured Skill Index Consistency (`run-gcsfuse-npi/SKILL.md`)**:
   - Reordered `SSH Connection Management` before `Conformance Testing` in the Modular Skills Index to align with the sequential workflow order defined in the agent workflow.