### PR TITLE
feat(agents): enforce mandatory POSIX and GKE E2E conformance testing across NPI targets

### DIFF
--- a/npi/.agents/agents/gcsfuse-npi-conformance-tester.md
+++ b/npi/.agents/agents/gcsfuse-npi-conformance-tester.md
@@ -1,6 +1,6 @@
 ---
 name: gcsfuse-npi-conformance-tester
-description: "Subagent specialized in managing persistent SSH connections, self-healing system build packages, executing POSIX conformance testing on GCE VM targets (make npi-conformance), executing CSI driver E2E tests on GKE clusters, monitoring watchdog log stalls, and exporting conformance_results_<TARGET_NAME>.json."
+description: "Subagent specialized in managing persistent SSH connections, self-healing system build packages, executing POSIX conformance testing on GCE VM targets (make npi-conformance), executing CSI driver E2E conformance tests on GKE clusters (gke-e2e-testing), monitoring watchdog log stalls, and exporting conformance_results_<TARGET_NAME>.json."
 enable_write_tools: true
 enable_subagent_tools: false
 enable_mcp_tools: true
@@ -10,6 +10,9 @@ enable_mcp_tools: true
 
 You are a specialized GCSFuse NPI Conformance and Integration Testing subagent. Your dedicated responsibility is to validate POSIX compatibility and functional correctness of GCSFuse across target GCE VMs and GKE clusters.
 
+> [!IMPORTANT]
+> **Mandatory Execution Policy**: Conformance and integration testing must ALWAYS be executed by default across all target platforms (GCE VMs via `make npi-conformance` and GKE clusters via `gke-e2e-testing`). Conformance testing must NEVER be skipped unless explicitly excluded or bypassed by the user.
+
 ---
 
 ## Assigned Skills & Procedures
@@ -17,13 +20,13 @@ You are a specialized GCSFuse NPI Conformance and Integration Testing subagent. 
 You must load and follow these skills using `view_file`:
 1. **[SSH Connection Management](../skills/ssh-connection-management/SKILL.md)**: Establish, verify, and clean persistent SSH master multiplexing sockets (`~/.ssh/sockets/<TARGET_NAME>.sock`).
 2. **[Conformance Testing](../skills/conformance-testing/SKILL.md)**: Execute POSIX conformance test suite (`make npi-conformance`) on target GCE VMs, monitor for log stalls (>5 min), and export `conformance_results_<TARGET_NAME>.json`.
-3. **[GKE E2E Testing](../skills/gke-e2e-testing/SKILL.md)**: Execute GCSFuse CSI Driver end-to-end Ginkgo test suite under strict isolated `KUBECONFIG` sessions on GKE clusters.
+3. **[GKE E2E Testing](../skills/gke-e2e-testing/SKILL.md)**: Execute GCSFuse CSI Driver end-to-end Ginkgo test suite under strict isolated `KUBECONFIG` sessions on GKE clusters and export `conformance_results_<TARGET_NAME>.json`.
 
 ---
 
 ## Execution Workflow
 
-1. **SSH Socket Verification**:
+1. **SSH Socket Verification** (for GCE VM targets):
    - Verify local directory `mkdir -p ~/.ssh/sockets`.
    - Check if socket `~/.ssh/sockets/<TARGET_NAME>.sock` exists. Test liveness with `ssh -O check -S ~/.ssh/sockets/<TARGET_NAME>.sock 2>/dev/null`. If stale, exit and remove it.
    - Establish master SSH connection resolving `SSH_USER="${SSH_USER:-$(gcloud config get-value account 2>/dev/null | tr '@.' '_')}"`:
@@ -40,14 +43,17 @@ You must load and follow these skills using `view_file`:
    - Parse results into structured JSON and transfer deliverable locally as `conformance_results_<TARGET_NAME>.json`.
    - **Non-blocking policy**: Do not block the pipeline on expected permission test failures; document them in the JSON deliverable.
 
-3. **GKE E2E Testing**:
+3. **GKE E2E Conformance Testing**:
    - Enforce isolated KUBECONFIG: `mkdir -p ~/.kube && export KUBECONFIG=~/.kube/npi_kubeconfig`.
    - Retrieve cluster credentials: `gcloud container clusters get-credentials <CLUSTER> --location=<LOCATION> --project=<PROJECT_ID>`.
-   - Execute Ginkgo E2E test suite under `gcs-fuse-csi-driver` directory. Clean up test namespaces after execution.
+   - Execute Ginkgo E2E test suite under `gcs-fuse-csi-driver` directory (`make e2e-test`).
+   - Parse Ginkgo test execution results into local deliverable `conformance_results_<TARGET_NAME>.json`.
+   - Clean up test namespaces after execution.
 
 ---
 
 ## Verification & Deliverables
 
-- Confirm `conformance_results_<TARGET_NAME>.json` exists locally and satisfies schema (`timestamp`, `summary.total_tests >= 1`, `tests`).
-- Ensure no lingering FUSE mounts (`/tmp/gcsfuse_*`) remain on target VMs.
+- Confirm `conformance_results_<TARGET_NAME>.json` exists locally for all targets and satisfies schema (`timestamp`, `summary.total_tests >= 1`, `tests`).
+- Ensure no lingering FUSE mounts (`/tmp/gcsfuse_*`) remain on target VMs or lingering test namespaces on GKE.
+

--- a/npi/.agents/agents/gcsfuse-npi-runner.md
+++ b/npi/.agents/agents/gcsfuse-npi-runner.md
@@ -17,7 +17,7 @@ You are the Master Orchestrator Agent for the GCSFuse New Product Introduction (
 You coordinate a team of focused, specialized subagents:
 
 1. **`gcsfuse-npi-conformance-tester`**:
-   - **Role**: Manages SSH sockets, validates system packages, executes POSIX conformance tests (`make npi-conformance`) on GCE VMs and CSI Driver E2E tests on GKE clusters, monitors 5-min log stall watchdog, and parses results into `conformance_results_<TARGET_NAME>.json`.
+   - **Role**: Manages SSH sockets, validates system packages, executes POSIX conformance tests (`make npi-conformance`) on GCE VMs and CSI Driver E2E conformance tests on GKE clusters (`gke-e2e-testing`), monitors 5-min log stall watchdog, and parses results into `conformance_results_<TARGET_NAME>.json`.
    - **Associated Skills**: [SSH Connection Management](../skills/ssh-connection-management/SKILL.md), [Conformance Testing](../skills/conformance-testing/SKILL.md), [GKE E2E Testing](../skills/gke-e2e-testing/SKILL.md).
 
 2. **`gcsfuse-npi-benchmarker`**:
@@ -47,7 +47,7 @@ You must coordinate the pipeline stages sequentially:
                                          v
 +-----------------------------------------------------------------------------------+
 | Stage 2: Conformance & Integration Testing                                        |
-| Delegate to `gcsfuse-npi-conformance-tester` (SSH setup + make npi-conformance)    |
+| Delegate to `gcsfuse-npi-conformance-tester` (GCE make npi-conformance & GKE E2E)  |
 +-----------------------------------------------------------------------------------+
                                          |
                                          v
@@ -84,6 +84,7 @@ You must coordinate the pipeline stages sequentially:
   2. GCS Bucket Details (Regional vs Zonal RAPID, colocation, HNS status).
   3. Run Details & Scope (GCSFuse branch, smoke vs full mode, benchmark matrices).
   4. Target Environment Readiness (SSH sockets, Docker, GKE node pools, Workload Identity & CSI Driver status).
+- **Mandatory Conformance Testing by Default**: Stage 2 Conformance and Integration Testing is mandatory for ALL target platforms (GCE VMs via `make npi-conformance` and GKE clusters via `gke-e2e-testing`) and must ALWAYS be executed by default during qualification. Conformance testing must NEVER be skipped unless explicitly requested to be excluded by the user.
 - **Smoke Test Matrix Lifecycle**: For smoke test runs, ensure `fio/read_matrix.csv` and `fio/write_matrix.csv` are modified before container builds and restored via `git restore` immediately after image build initiation.
 - **Dynamic Target Inspection**: Extract target configurations from the user's prompt into `targets.json`. For GKE cluster targets, inspect worker nodes for local SSDs to determine `"has_ssd"`, not the intermediate controller VM.
 - **Sequential Execution**: Run conformance testing and performance benchmarking sequentially to avoid host resource contention.

--- a/npi/.agents/skills/conformance-testing/SKILL.md
+++ b/npi/.agents/skills/conformance-testing/SKILL.md
@@ -1,47 +1,49 @@
 ---
 name: conformance-testing
-description: Guides on cloning GCSFuse, executing Makefile npi-conformance target on target GCE VMs, parsing integration_tests.log into conformance_results_<TARGET_NAME>.json, enforcing non-blocking permission error policies, handling 5-minute log stall timeouts via pkill and umount cleanup, and skipping unsupported GKE cluster environments.
+description: Guides on cloning GCSFuse, executing Makefile npi-conformance target on target GCE VMs, coordinating GKE cluster E2E conformance testing via gke-e2e-testing, parsing test logs into conformance_results_<TARGET_NAME>.json, enforcing non-blocking permission error policies, and handling 5-minute log stall timeouts via pkill and umount cleanup.
 ---
 
 # GCSFuse Conformance and Integration Testing
 
-This skill guides you through checking out the official GCSFuse repository, executing integration and POSIX conformance test suites on a target GCE VM using the standardized `make npi-conformance` target, parsing test output logs, and generating `conformance_results_<TARGET_NAME>.json`.
+This skill guides you through checking out the official GCSFuse repository, executing integration and POSIX conformance test suites on target platforms (GCE VMs using the standardized `make npi-conformance` target and GKE clusters using the `gke-e2e-testing` skill), parsing test output logs, and generating `conformance_results_<TARGET_NAME>.json`.
 
 > [!IMPORTANT]
-> **GCE VM Targets Only**: Conformance and integration testing (`go test` execution) is supported ONLY on GCE VM targets. For GKE cluster targets, conformance testing is skipped because GKE validation relies on GKE performance benchmark workloads. Do not attempt to run conformance tests on GKE nodes.
+> **Mandatory Execution Policy**: Conformance and integration testing is mandatory across all target platforms (both GCE VM and GKE cluster targets) and must ALWAYS be executed by default during NPI qualification. Conformance testing must NEVER be skipped unless the user explicitly requests to exclude or bypass conformance testing.
 
 ## Prerequisites & Trigger Conditions
 
 ### Prerequisites
 1. **Go Language Environment**: Go installed on target GCE VM matching GCSFuse `go.mod` (typically Go 1.22+).
 2. **GCP Storage Credentials**: Target GCE VM service account configured with permissions to read/write test GCS buckets (`storage-rw` scope or `Storage Object Admin` role).
-3. **Active Master SSH Connection**: Established SSH connection socket at `~/.ssh/sockets/<TARGET_NAME>.sock`.
+3. **Active Master SSH Connection**: Established SSH connection socket at `~/.ssh/sockets/<TARGET_NAME>.sock` for GCE VM targets.
 4. **Target GCS Bucket**: Dedicated test bucket for integration test file operations.
 5. **KUBECONFIG Isolation Policy**: Standard policy enforcing `mkdir -p ~/.kube && export KUBECONFIG=~/.kube/npi_kubeconfig` for any cluster interactions, ensuring host default `~/.kube/config` remains unmutated.
 
 ### Trigger Conditions
-- Validating POSIX compatibility and functional correctness of GCSFuse on a target GCE VM platform.
+- Validating POSIX compatibility and functional correctness of GCSFuse on a target GCE VM or GKE cluster platform.
 - Executed during NPI qualification prior to or alongside performance benchmarking suites.
-- Triggered when testing new GCSFuse code releases or feature branches on GCE VM targets.
+- Triggered when testing new GCSFuse code releases or feature branches across all targets.
 
 ## Input/Output Contract
 
 ### Inputs
-- **Target SSH Socket**: Socket path `~/.ssh/sockets/<TARGET_NAME>.sock`.
-- **Target GCE VM Specs**: VM Name, Zone, GCP Project ID, SSH User.
+- **Target SSH Socket**: Socket path `~/.ssh/sockets/<TARGET_NAME>.sock` (for GCE VM targets).
+- **Target Specs**: VM Name, Zone, GCP Project ID, Cluster Name, SSH User.
 - **Makefile Parameters**: `PROJECT=<PROJECT_ID>`, `BUCKET_LOCATION=<REGION>`, `READ_AHEAD_KB=<KB>` (defaults to 128).
 - **GCSFuse Version / Branch**: Git commit tag or branch name (`<GCSFUSE_VERSION_OR_BRANCH>`, default: `master`).
 
 ### Outputs
-- **Remote Log**: `~/integration_tests.log` generated on target VM.
+- **Remote Log**: `~/integration_tests.log` generated on target VM (for GCE) or Ginkgo E2E logs (for GKE).
 - **Local Deliverable**: `conformance_results_<TARGET_NAME>.json` containing:
-  - ISO 8601 Timestamp, GCSFuse version, target VM name.
+  - ISO 8601 Timestamp, GCSFuse version, target name.
   - Summary metrics: `total_tests`, `passed`, `failed`, `skipped`.
   - Detailed list of individual test cases, pass/fail status, execution duration, and error strings.
 
 ## Step-by-Step Procedure
 
-### Step 1: System Package Self-Healing & Repository Clone on Target VM
+### For GCE VM Targets:
+
+#### Step 1: System Package Self-Healing & Repository Clone on Target VM
 
 Connect to the target VM using the master SSH socket, resolving `SSH_USER="${SSH_USER:-$(gcloud config get-value account 2>/dev/null | tr '@.' '_')}"`, verify missing build packages (`build-essential`, `make`, `docker.io`), install if absent, and clone GCSFuse:
 ```bash
@@ -57,11 +59,11 @@ ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o IdentitiesOnly=yes -o StrictHostKeyC
 EOF
 ```
 
-### Step 2: Prepare Test Bucket and Config
+#### Step 2: Prepare Test Bucket and Config
 
 Verify environmental parameters on the target VM (e.g., `GCSFUSE_TEST_BUCKET`).
 
-### Step 3: Run Integration Tests via `make npi-conformance`
+#### Step 3: Run Integration Tests via `make npi-conformance`
 
 > [!IMPORTANT]
 > **Makefile Integration**:
@@ -80,7 +82,7 @@ ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o IdentitiesOnly=yes -o StrictHostKeyC
 EOF
 ```
 
-### Step 4: Parse Log and Generate `conformance_results_<TARGET_NAME>.json`
+#### Step 4: Parse Log and Generate `conformance_results_<TARGET_NAME>.json`
 
 Parse `~/integration_tests.log` on target VM and export structured JSON:
 
@@ -117,11 +119,23 @@ Copy the generated JSON report to local machine:
 scp -S ~/.ssh/sockets/<TARGET_NAME>.sock -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine ${SSH_USER}@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com:~/conformance_results.json ./conformance_results_<TARGET_NAME>.json
 ```
 
+---
+
+### For GKE Cluster Targets:
+
+For GKE cluster targets, execute the GCSFuse CSI Driver end-to-end conformance test suite following the **[GKE E2E Testing](../gke-e2e-testing/SKILL.md)** skill:
+1. Enforce isolated KUBECONFIG: `mkdir -p ~/.kube && export KUBECONFIG=~/.kube/npi_kubeconfig`.
+2. Connect to the target GKE cluster and verify node and CSI driver readiness.
+3. Run the Ginkgo E2E test suite in `gcs-fuse-csi-driver` repository: `make e2e-test`.
+4. Parse Ginkgo test execution results and generate `./conformance_results_<TARGET_NAME>.json`.
+
+---
+
 ## Failure Modes & Edge Cases
 
 | Failure Scenario | Root Cause | Remediation / Recovery Action |
 |---|---|---|
-| **Target is GKE Cluster** | Conformance testing attempted on GKE node | Skip conformance testing on GKE targets. Document GKE skip policy in report and rely on GKE benchmark runs. |
+| **Target is GKE Cluster** | Running conformance on GKE target | Follow `gke-e2e-testing` skill to execute CSI driver E2E tests under isolated `KUBECONFIG` and export structured results to `conformance_results_<TARGET_NAME>.json`. Do NOT skip conformance on GKE unless explicitly instructed by the user. |
 | **Missing System Packages** | VM image lacks `make`, `gcc`, or `docker` | Self-healing check auto-installs `build-essential make docker.io` prior to running tests. |
 | **5-Minute Log Stall / Process Hang** | `go test` or GCSFuse daemon deadlocked during test execution | Check remote log `~/integration_tests.log` size every 5 mins. If size is unchanged for >5 mins: <br> 1. Terminate processes: `ssh ... "sudo pkill -9 -f 'go test' ; sudo pkill -9 gcsfuse ; sudo pkill -9 -f proxy_server"` <br> 2. Force unmount leftover mounts: `ssh ... "sudo umount -f /tmp/gcsfuse_readwrite_test_*/mnt || true"` <br> 3. Clean temp directories: `ssh ... "sudo rm -rf /tmp/gcsfuse_*"` <br> 4. Record stall in JSON. |
 | **Permission Failure Tests** | Test asserts bucket operations restricted by service account permissions | Non-blocking policy. Do NOT abort pipeline. Parse and record test failures in `conformance_results_<TARGET_NAME>.json` and document in final report. |
@@ -141,3 +155,4 @@ scp -S ~/.ssh/sockets/<TARGET_NAME>.sock -o IdentitiesOnly=yes -o StrictHostKeyC
    ```bash
    ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine ${SSH_USER}@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com "mount | grep gcsfuse_readwrite_test || echo 'NO_LEFTOVER_MOUNTS'"
    ```
+

--- a/npi/.agents/skills/gke-e2e-testing/SKILL.md
+++ b/npi/.agents/skills/gke-e2e-testing/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: gke-e2e-testing
-description: Guides on provisioning GKE clusters (e.g. n2-standard-64) with Workload Identity and GCSFuse CSI Driver addon enabled, enforcing isolated KUBECONFIG policy, configuring gcs-fuse-csi-driver test suite, executing end-to-end (e2e) tests, and monitoring Ginkgo test execution.
+description: Guides on provisioning GKE clusters (e.g. n2-standard-64) with Workload Identity and GCSFuse CSI Driver addon enabled, enforcing isolated KUBECONFIG policy, configuring gcs-fuse-csi-driver test suite, executing end-to-end (e2e) tests, and parsing Ginkgo test outputs into conformance_results_<TARGET_NAME>.json.
 ---
 
-# GCSFuse End-to-End (E2E) Testing on GKE
+# GCSFuse End-to-End (E2E) Conformance Testing on GKE
 
-This skill guides you through provisioning GKE compute clusters, configuring strict isolated KUBECONFIG sessions, setting up the GCSFuse CSI Driver test environment, and executing the GCSFuse end-to-end (E2E) test suite using Ginkgo.
+This skill guides you through configuring strict isolated KUBECONFIG sessions, setting up the GCSFuse CSI Driver test environment, executing the GCSFuse end-to-end (E2E) conformance test suite using Ginkgo on GKE cluster targets, and generating `conformance_results_<TARGET_NAME>.json`.
+
+> [!IMPORTANT]
+> **Mandatory Execution Policy**: GKE E2E conformance testing is mandatory by default during NPI qualification for GKE targets. It must ALWAYS be executed to validate functional correctness and POSIX integration unless the user explicitly requests to exclude or skip conformance testing.
 
 ---
 
@@ -13,13 +16,13 @@ This skill guides you through provisioning GKE compute clusters, configuring str
 
 ### Prerequisites
 1. **GCP Project Access & Permissions**: Local environment configured with `gcloud`, `kubectl`, and `go` (1.24+) CLI tools with permissions to create GKE clusters (`container.clusters.create`), storage buckets (`storage.buckets.create`), and IAM service accounts (`resourcemanager.projects.get`).
-2. **KUBECONFIG Isolation Policy**: Standard policy enforcing `mkdir -p ~/.kube && export KUBECONFIG=~/.kube/npi_kubeconfig` for all cluster creation and `kubectl` operations, ensuring the host default `~/.kube/config` remains completely unmutated.
+2. **KUBECONFIG Isolation Policy**: Standard policy enforcing `mkdir -p ~/.kube && export KUBECONFIG=~/.kube/npi_kubeconfig` for all cluster interactions and `kubectl` operations, ensuring the host default `~/.kube/config` remains completely unmutated.
 3. **GCSFuse CSI Driver Repository**: Repository clone of `gcs-fuse-csi-driver` (e.g. at `~/gitproj/gcs-fuse-csi-driver` or local workspace).
 4. **Ginkgo Test Framework**: `ginkgo` v2.27.0+ installed (`go install github.com/onsi/ginkgo/v2/ginkgo@v2.27.0`).
 
 ### Trigger Conditions
-- Triggered when requested to validate functional correctness and E2E integration of GCSFuse on GKE clusters.
-- Executed when validating GCSFuse behavior against custom GKE cluster machine types (e.g., `n2-standard-64`, `n2-standard-96`).
+- Triggered when validating functional correctness, POSIX compatibility, and E2E integration of GCSFuse on GKE clusters.
+- Executed during Stage 2 (Conformance & Integration Testing) of the NPI pipeline on GKE cluster targets.
 - Used to test GCSFuse CSI Driver volume mounting, bucket creation, file caching, kernel list cache, and workload identity integration.
 
 ---
@@ -30,7 +33,7 @@ This skill guides you through provisioning GKE compute clusters, configuring str
 - **`PROJECT_ID`**: GCP Project ID (e.g. `gcs-fuse-test`).
 - **`CLUSTER_NAME`**: Name of the target GKE cluster (e.g. `gcsfuse-n2s64-e2e-cluster`).
 - **`ZONE_OR_REGION`**: GCP Zone or Region (e.g. `us-central1-c`).
-- **`MACHINE_TYPE`**: Worker node machine type (e.g. `n2-standard-64`).
+- **`MACHINE_TYPE`**: Worker node machine type (e.g. `n2-standard-64` or `ct6e-standard-4t`).
 - **`E2E_TEST_USE_GKE_MANAGED_DRIVER`**: Set to `true` when testing against GKE pre-installed GCSFuse CSI driver.
 - **`E2E_TEST_GINKGO_PROCS`**: Parallel test worker count (default: `5`).
 
@@ -38,6 +41,7 @@ This skill guides you through provisioning GKE compute clusters, configuring str
 - **GKE Cluster**: Active GKE cluster with Workload Identity and GCSFuse CSI Driver addon enabled.
 - **Kubeconfig Context**: Isolated context configured in `~/.kube/npi_kubeconfig`.
 - **E2E Test Execution Logs**: Ginkgo test logs showing test spec status (Pass/Fail/Skip).
+- **Deliverable**: `conformance_results_<TARGET_NAME>.json` containing parsed E2E test results, summaries, and individual test cases.
 
 ---
 

--- a/npi/.agents/skills/run-gcsfuse-npi/SKILL.md
+++ b/npi/.agents/skills/run-gcsfuse-npi/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: run-gcsfuse-npi
-description: Master entrypoint and orchestration skill for running the end-to-end GCSFuse Network Performance Improvement (NPI) pipeline across modular skills, coordinating SSH socket setup, bucket creation via bucket-creation skill, target buffer mounting via raid0-script.sh, image building via build_images.py, POSIX & E2E conformance testing across all targets (GCE VMs via make npi-conformance and GKE clusters via gke-e2e-testing), benchmark suite execution via npi_orchestrator.py, analysis and validation report generation in npi_validation_report.md, and remediation planning in npi_remediation_plan.md.
+description: Master entrypoint and orchestration skill for running the end-to-end GCSFuse New Product Introduction (NPI) pipeline across modular skills, coordinating SSH socket setup, bucket creation via bucket-creation skill, target buffer mounting via raid0-script.sh, image building via build_images.py, POSIX & E2E conformance testing across all targets (GCE VMs via make npi-conformance and GKE clusters via gke-e2e-testing), benchmark suite execution via npi_orchestrator.py, analysis and validation report generation in npi_validation_report.md, and remediation planning in npi_remediation_plan.md.
 ---
 
 # GCSFuse NPI Master Orchestration Entrypoint
 
-This skill serves as the primary master entrypoint for executing and orchestrating the complete end-to-end GCSFuse Network Performance Improvement (NPI) validation, benchmarking, POSIX & E2E conformance testing, analysis, and remediation pipeline across all modular skills.
+This skill serves as the primary master entrypoint for executing and orchestrating the complete end-to-end GCSFuse New Product Introduction (NPI) validation, benchmarking, POSIX & E2E conformance testing, analysis, and remediation pipeline across all modular skills.
 
 ---
 

--- a/npi/.agents/skills/run-gcsfuse-npi/SKILL.md
+++ b/npi/.agents/skills/run-gcsfuse-npi/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: run-gcsfuse-npi
-description: Master entrypoint and orchestration skill for running the end-to-end GCSFuse Network Performance Improvement (NPI) pipeline across modular skills, coordinating SSH socket setup, bucket creation via bucket-creation skill, target buffer mounting via raid0-script.sh, image building via build_images.py, POSIX conformance testing via make npi-conformance, benchmark suite execution via npi_orchestrator.py, analysis and validation report generation in npi_validation_report.md, and remediation planning in npi_remediation_plan.md.
+description: Master entrypoint and orchestration skill for running the end-to-end GCSFuse Network Performance Improvement (NPI) pipeline across modular skills, coordinating SSH socket setup, bucket creation via bucket-creation skill, target buffer mounting via raid0-script.sh, image building via build_images.py, POSIX & E2E conformance testing across all targets (GCE VMs via make npi-conformance and GKE clusters via gke-e2e-testing), benchmark suite execution via npi_orchestrator.py, analysis and validation report generation in npi_validation_report.md, and remediation planning in npi_remediation_plan.md.
 ---
 
 # GCSFuse NPI Master Orchestration Entrypoint
 
-This skill serves as the primary master entrypoint for executing and orchestrating the complete end-to-end GCSFuse Network Performance Improvement (NPI) validation, benchmarking, POSIX conformance testing, analysis, and remediation pipeline across all modular skills.
+This skill serves as the primary master entrypoint for executing and orchestrating the complete end-to-end GCSFuse Network Performance Improvement (NPI) validation, benchmarking, POSIX & E2E conformance testing, analysis, and remediation pipeline across all modular skills.
 
 ---
 
@@ -36,7 +36,7 @@ This skill serves as the primary master entrypoint for executing and orchestrati
   1. Active master SSH sockets at `~/.ssh/sockets/<TARGET_NAME>.sock` (via `ssh-connection-management`).
   2. Provisioned Regional or Zonal RAPID GCS buckets with HNS enabled (via `bucket-creation`).
   3. Mounted target storage buffers (RAID0 or `tmpfs` RAM disk) and pushed container image `us-docker.pkg.dev/<PROJECT_ID>/gcsfuse-npi-images:<IMAGE_VERSION>` (via `benchmark-build-setup`).
-  4. `conformance_results_<TARGET_NAME>.json` for GCE VM targets (via `conformance-testing`).
+  4. `conformance_results_<TARGET_NAME>.json` for all target environments (GCE VMs via `conformance-testing`, GKE clusters via `gke-e2e-testing`).
   5. BigQuery benchmark datasets (`<prefix>_regional` or `_zonal`) containing `host_info` and `fio_*` metrics (via `benchmark-suite-execution`).
   6. `npi_validation_report.md` with explicit PASS/FAIL verdict for the 20 GB/s non-pinned SLA gate (via `analysis-report-generation`).
   7. `npi_remediation_plan.md` outlining tuning recommendations if SLA gate fails or regressions >5% occur (via `remediation-advisor`).
@@ -67,8 +67,8 @@ The end-to-end pipeline executes sequentially through modular phases:
                                          |
                                          v
 +-----------------------------------------------------------------------------------+
-| Phase 3: POSIX Conformance & Integration Testing                                  |
-| Execute `make npi-conformance` on GCE VMs (skip GKE) & export JSON results        |
+| Phase 3: POSIX & E2E Conformance Testing                                         |
+| Execute conformance tests across all targets (GCE VMs & GKE) & export JSON results|
 +-----------------------------------------------------------------------------------+
                                          |
                                          v
@@ -125,17 +125,25 @@ The end-to-end pipeline executes sequentially through modular phases:
    ```
 6. Restore matrix files if smoke-test matrices were edited (`git restore fio/read_matrix.csv fio/write_matrix.csv`).
 
-### Phase 3: POSIX Conformance & Integration Testing
+### Phase 3: POSIX & E2E Conformance Testing
 *Skill Reference*: **[Conformance Testing](../conformance-testing/SKILL.md)** for GCE VMs, **[GKE E2E Testing](../gke-e2e-testing/SKILL.md)** for GKE Clusters
-1. For GKE targets, execute GCSFuse CSI Driver E2E integration tests using Ginkgo (`make e2e-test` via `gke-e2e-testing` skill).
-2. For GCE VM targets, clone GCSFuse repo on target VM (`~/gcsfuse`).
-3. Execute standardized Makefile target (default branch `master`):
-   ```bash
-   SSH_USER="${SSH_USER:-$(gcloud config get-value account 2>/dev/null | tr '@.' '_')}"
-   ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine ${SSH_USER}@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com "cd ~/gcsfuse && make npi-conformance PROJECT=<PROJECT_ID> BUCKET_LOCATION=<REGION> READ_AHEAD_KB=128 GCSFUSE_VERSION=master > ~/integration_tests.log 2>&1"
-   ```
-4. Monitor remote log growth. If log size stalls for >5 minutes, kill processes (`pkill -9`), force unmount (`umount -f`), clean temp files, and record stall.
-5. Parse `~/integration_tests.log` and copy `conformance_results_<TARGET_NAME>.json` back to local orchestrator using `scp -S ~/.ssh/sockets/<TARGET_NAME>.sock -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine`. Enforce non-blocking policy on permission failures.
+
+> [!IMPORTANT]
+> **Mandatory Execution Policy**: Conformance and integration testing is mandatory for ALL targets (both GCE VMs and GKE clusters) and must ALWAYS be executed by default during NPI qualification. Do NOT skip conformance testing unless the user explicitly requests to exclude it.
+
+1. **For GKE Targets**:
+   - Enforce isolated KUBECONFIG: `mkdir -p ~/.kube && export KUBECONFIG=~/.kube/npi_kubeconfig`.
+   - Connect to target cluster and execute GCSFuse CSI Driver E2E integration test suite (`make e2e-test` via `gke-e2e-testing` skill).
+   - Parse Ginkgo test outputs into `./conformance_results_<TARGET_NAME>.json`.
+2. **For GCE VM Targets**:
+   - Clone GCSFuse repo on target VM (`~/gcsfuse`).
+   - Execute standardized Makefile target (default branch `master`):
+     ```bash
+     SSH_USER="${SSH_USER:-$(gcloud config get-value account 2>/dev/null | tr '@.' '_')}"
+     ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine ${SSH_USER}@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com "cd ~/gcsfuse && make npi-conformance PROJECT=<PROJECT_ID> BUCKET_LOCATION=<REGION> READ_AHEAD_KB=128 GCSFUSE_VERSION=master > ~/integration_tests.log 2>&1"
+     ```
+   - Monitor remote log growth. If log size stalls for >5 minutes, kill processes (`pkill -9`), force unmount (`umount -f`), clean temp files, and record stall.
+   - Parse `~/integration_tests.log` and copy `conformance_results_<TARGET_NAME>.json` back to local orchestrator using `scp -S ~/.ssh/sockets/<TARGET_NAME>.sock -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine`. Enforce non-blocking policy on permission failures.
 
 ### Phase 4: Benchmark Suite Execution
 *Skill Reference*: **[Benchmark Suite Execution](../benchmark-suite-execution/SKILL.md)**
@@ -195,7 +203,7 @@ Verify complete end-to-end pipeline deliverables upon completion:
    ```bash
    gcloud artifacts docker images list us-docker.pkg.dev/<PROJECT_ID>/gcsfuse-npi-images --image-format='value(format("{0}:{1}",package,tag))' | grep "<IMAGE_VERSION>"
    ```
-3. **Phase 3 Conformance JSON Check** (for GCE VM targets):
+3. **Phase 3 Conformance JSON Check** (for all targets):
    ```bash
    test -s ./conformance_results_<TARGET_NAME>.json && jq .summary ./conformance_results_<TARGET_NAME>.json
    ```


### PR DESCRIPTION
## Overview
This PR updates the NPI Agent definitions and skills to enforce mandatory Stage 2 conformance and integration testing by default across all target environments (both GCE VMs and GKE clusters).

## Key Changes
1. **gcsfuse-npi-runner**: Updated Stage 2 orchestration policy so conformance testing is mandatory across both GCE VMs and GKE clusters by default during qualification runs.
2. **gcsfuse-npi-conformance-tester**: Added GKE E2E conformance testing workflows (gke-e2e-testing) and standard JSON results export (conformance_results_<TARGET_NAME>.json).
3. **conformance-testing Skill**: Added explicit GKE E2E conformance testing procedures and updated failure modes to prevent skipping conformance testing on GKE.
4. **gke-e2e-testing Skill**: Standardized deliverable output format to conformance_results_<TARGET_NAME>.json and clarified NPI qualification triggers.
5. **run-gcsfuse-npi Skill**: Updated master entrypoint documentation, ASCII workflow diagram, and verification checks for mandatory POSIX and GKE E2E conformance testing.

## Verification
- Verified agent prompts, skill markdown files, and cross-references.