### PR TITLE
feat(npi): add support for extra-mount-options in npi.py and orchestrator

### DIFF
--- a/npi/npi.py
+++ b/npi/npi.py
@@ -51,7 +51,7 @@ class BenchmarkFactory:
         mount_path (str): The path to an already mounted GCS bucket.
     """
 
-    def __init__(self, bucket_name, project_id, bq_dataset_id, iterations, mount_path=None, image_version="latest", buffer_mount_path=None, file_cache_size_mb=2097152, smoke_mode=False):
+    def __init__(self, bucket_name, project_id, bq_dataset_id, iterations, mount_path=None, image_version="latest", buffer_mount_path=None, file_cache_size_mb=2097152, smoke_mode=False, extra_mount_options=None):
         """Initializes the BenchmarkFactory.
 
         Args:
@@ -61,6 +61,10 @@ class BenchmarkFactory:
             iterations (int): The number of benchmark iterations.
             mount_path (str): The path to an already mounted GCS bucket.
             image_version (str): The version of the benchmark Docker images.
+            buffer_mount_path (str): The host directory for storage buffer.
+            file_cache_size_mb (int): The file cache size in MB.
+            smoke_mode (bool): Whether to run in smoke test mode.
+            extra_mount_options (str, optional): Extra mount options for GCSFuse.
         """
         self.bucket_name = bucket_name
         self.project_id = project_id
@@ -71,7 +75,41 @@ class BenchmarkFactory:
         self.buffer_mount_path = buffer_mount_path
         self.file_cache_size_mb = file_cache_size_mb
         self.smoke_mode = smoke_mode
+        self.extra_mount_options = extra_mount_options
         self._benchmark_definitions = self._get_benchmark_definitions()
+
+    def _format_extra_mount_options(self, extra_opts):
+        """Formats extra mount options string into GCSFuse CLI flags."""
+        if not extra_opts or not extra_opts.strip():
+            return ""
+
+        extra_opts = extra_opts.strip()
+        if "," in extra_opts:
+            parts = [p.strip() for p in extra_opts.split(",") if p.strip()]
+        else:
+            try:
+                parts = shlex.split(extra_opts)
+            except ValueError:
+                parts = [p.strip() for p in extra_opts.split() if p.strip()]
+
+        formatted = []
+        i = 0
+        while i < len(parts):
+            p = parts[i].strip()
+            if not p:
+                i += 1
+                continue
+            if p == "-o" and i + 1 < len(parts):
+                next_part = parts[i + 1].strip()
+                formatted.append(f"-o {next_part}")
+                i += 2
+                continue
+            if p.startswith("-"):
+                formatted.append(p)
+            else:
+                formatted.append(f"--{p}")
+            i += 1
+        return " ".join(formatted)
 
     def get_benchmark_command(self, name):
         """Generates the command for a given benchmark name.
@@ -141,6 +179,11 @@ class BenchmarkFactory:
         else:
             gcsfuse_flags = default_gcsfuse_flags
         gcsfuse_flags += " --log-file=/gcsfuse-buffer/gcsfuse.log --log-format=json"
+
+        if self.extra_mount_options:
+            extra_flags = self._format_extra_mount_options(self.extra_mount_options)
+            if extra_flags:
+                gcsfuse_flags = f"{gcsfuse_flags} {extra_flags}"
 
         num_jobs = "2" if self.smoke_mode else "112"
         base_cmd = (
@@ -482,6 +525,11 @@ def main():
         action="store_true",
         help="If set, run in fast smoke test mode with reduced iterations and thread counts."
     )
+    parser.add_argument(
+        "--extra-mount-options",
+        default=None,
+        help="Extra mount options to pass to GCSFuse (comma-separated or space-separated, e.g., 'congestion-threshold=384,max-background=512')."
+    )
 
     args = parser.parse_args()
 
@@ -521,7 +569,8 @@ def main():
         image_version=args.image_version,
         buffer_mount_path=args.buffer_mount_path,
         file_cache_size_mb=args.file_cache_size_mb,
-        smoke_mode=args.smoke_mode
+        smoke_mode=args.smoke_mode,
+        extra_mount_options=args.extra_mount_options
     )
 
     available_benchmarks = factory.get_available_benchmarks()

--- a/npi/npi_orchestrator.py
+++ b/npi/npi_orchestrator.py
@@ -790,6 +790,15 @@ def execute_target(target, args, state_lock, state):
             suffix = "_zonal" if is_rapid else "_regional"
             dataset_id = f"{base_dataset}{suffix}"
 
+            extra_mount_opts = []
+            target_extra = target.get("extra_mount_options")
+            if target_extra and str(target_extra).strip():
+                extra_mount_opts.append(str(target_extra).strip())
+            cli_extra = getattr(args, "extra_mount_options", None)
+            if cli_extra and str(cli_extra).strip():
+                extra_mount_opts.append(str(cli_extra).strip())
+            combined_extra_mount_opts = ",".join(extra_mount_opts) if extra_mount_opts else None
+
             if target["type"] == "gce":
                 python_args = [
                     "python3", "-u", f"/home/{SSH_USER}/gcsfuse-tools/npi/npi.py",
@@ -806,6 +815,8 @@ def execute_target(target, args, state_lock, state):
                 python_args.extend(["--benchmarks"] + active_benchmarks)
                 if target.get("buffer_mount"):
                     python_args.append(f"--buffer-mount-path={target['buffer_mount']}")
+                if combined_extra_mount_opts:
+                    python_args.append(f"--extra-mount-options={combined_extra_mount_opts}")
                     
                 python_cmd = " ".join(shlex.quote(arg) for arg in python_args)
                 full_cmd = f"{python_cmd}; echo $? > /tmp/npi_{target_name}.exit"
@@ -843,6 +854,8 @@ def execute_target(target, args, state_lock, state):
                         python_args.append("--run-file-cache-test")
                 
                 python_args.extend(["--benchmarks"] + active_benchmarks)
+                if combined_extra_mount_opts:
+                    python_args.append(f"--extra-mount-options={combined_extra_mount_opts}")
                 
                 python_cmd = " ".join(shlex.quote(arg) for arg in python_args)
                 full_cmd = f"{python_cmd}; echo $? > /tmp/npi_{target_name}.exit"
@@ -960,6 +973,7 @@ def main():
     parser.add_argument("--iterations", type=int, default=5, help="Number of iterations")
     parser.add_argument("--reset", action="store_true", help="Reset saved state and start a fresh run")
     parser.add_argument("--smoke-mode", action="store_true", help="Run orchestrator in fast smoke test mode")
+    parser.add_argument("--extra-mount-options", default=None, help="Extra mount options to pass to GCSFuse benchmarks")
     
     args = parser.parse_args()
     if args.smoke_mode and args.iterations == 5:

--- a/npi/npi_test.py
+++ b/npi/npi_test.py
@@ -1185,6 +1185,429 @@ class TestQueryResults(unittest.TestCase):
         })
 
 
+class TestBenchmarkFactoryExtraMountOptions(unittest.TestCase):
+
+    def setUp(self):
+        self.factory_default = npi.BenchmarkFactory(
+            bucket_name="test-bucket",
+            project_id="test-project",
+            bq_dataset_id="test-dataset",
+            iterations=5,
+            buffer_mount_path="/mnt/buffer"
+        )
+
+    def test_format_extra_mount_options_none_and_empty(self):
+        self.assertEqual(self.factory_default._format_extra_mount_options(None), "")
+        self.assertEqual(self.factory_default._format_extra_mount_options(""), "")
+        self.assertEqual(self.factory_default._format_extra_mount_options("   \n\t  "), "")
+
+    def test_format_extra_mount_options_single_flag(self):
+        self.assertEqual(
+            self.factory_default._format_extra_mount_options("implicit-dirs"),
+            "--implicit-dirs"
+        )
+        self.assertEqual(
+            self.factory_default._format_extra_mount_options("--implicit-dirs"),
+            "--implicit-dirs"
+        )
+
+    def test_format_extra_mount_options_comma_separated_key_values(self):
+        opts = "congestion-threshold=384,max-background=512"
+        formatted = self.factory_default._format_extra_mount_options(opts)
+        self.assertEqual(formatted, "--congestion-threshold=384 --max-background=512")
+
+        opts_with_spaces = "congestion-threshold=384, max-background=512, implicit-dirs"
+        formatted = self.factory_default._format_extra_mount_options(opts_with_spaces)
+        self.assertEqual(formatted, "--congestion-threshold=384 --max-background=512 --implicit-dirs")
+
+    def test_format_extra_mount_options_space_separated_key_values(self):
+        opts = "congestion-threshold=384 max-background=512"
+        formatted = self.factory_default._format_extra_mount_options(opts)
+        self.assertEqual(formatted, "--congestion-threshold=384 --max-background=512")
+
+    def test_format_extra_mount_options_prefixed_flags_no_double_hyphen(self):
+        opts = "--custom-opt=val --debug_gcs"
+        formatted = self.factory_default._format_extra_mount_options(opts)
+        self.assertEqual(formatted, "--custom-opt=val --debug_gcs")
+
+        opts_comma = "--custom-opt=val, --debug_gcs"
+        formatted = self.factory_default._format_extra_mount_options(opts_comma)
+        self.assertEqual(formatted, "--custom-opt=val --debug_gcs")
+
+    def test_format_extra_mount_options_dash_o_flag_preserved(self):
+        opts_space = "-o allow_other --custom-flag=1"
+        formatted = self.factory_default._format_extra_mount_options(opts_space)
+        self.assertEqual(formatted, "-o allow_other --custom-flag=1")
+
+        opts_comma = "-o allow_other,congestion-threshold=384"
+        formatted = self.factory_default._format_extra_mount_options(opts_comma)
+        self.assertEqual(formatted, "-o allow_other --congestion-threshold=384")
+
+        opts_comma_split = "-o,allow_other,congestion-threshold=384"
+        formatted = self.factory_default._format_extra_mount_options(opts_comma_split)
+        self.assertEqual(formatted, "-o allow_other --congestion-threshold=384")
+
+    @patch('npi.BenchmarkFactory._get_cpu_list_for_numa_node')
+    def test_get_benchmark_command_standard_with_extra_mount_options(self, mock_get_cpu):
+        mock_get_cpu.return_value = None
+        factory = npi.BenchmarkFactory(
+            bucket_name="test-bucket",
+            project_id="test-project",
+            bq_dataset_id="test-dataset",
+            iterations=5,
+            buffer_mount_path="/mnt/buffer",
+            extra_mount_options="congestion-threshold=384,max-background=512"
+        )
+        cmd, table_id = factory.get_benchmark_command("read_grpc")
+        self.assertEqual(table_id, "fio_read_grpc")
+        self.assertIn("-v /mnt/buffer:/gcsfuse-buffer", cmd)
+        self.assertIn("--temp-dir=/gcsfuse-buffer/write", cmd)
+        self.assertIn("-o allow_other", cmd)
+        self.assertIn("--client-protocol=grpc", cmd)
+        self.assertIn("--log-file=/gcsfuse-buffer/gcsfuse.log", cmd)
+        self.assertIn("--log-format=json", cmd)
+        self.assertIn("--congestion-threshold=384", cmd)
+        self.assertIn("--max-background=512", cmd)
+
+    @patch('npi.BenchmarkFactory._get_cpu_list_for_numa_node')
+    def test_get_benchmark_command_standard_without_extra_mount_options(self, mock_get_cpu):
+        mock_get_cpu.return_value = None
+        factory = npi.BenchmarkFactory(
+            bucket_name="test-bucket",
+            project_id="test-project",
+            bq_dataset_id="test-dataset",
+            iterations=5,
+            buffer_mount_path="/mnt/buffer",
+            extra_mount_options=None
+        )
+        cmd, table_id = factory.get_benchmark_command("read_grpc")
+        self.assertEqual(table_id, "fio_read_grpc")
+        self.assertIn("-v /mnt/buffer:/gcsfuse-buffer", cmd)
+        self.assertIn("--temp-dir=/gcsfuse-buffer/write", cmd)
+        self.assertIn("--client-protocol=grpc", cmd)
+        self.assertNotIn("--congestion-threshold", cmd)
+        self.assertNotIn("--max-background", cmd)
+
+    @patch('npi.BenchmarkFactory._get_cpu_list_for_numa_node')
+    def test_get_benchmark_command_file_cache_with_extra_mount_options(self, mock_get_cpu):
+        mock_get_cpu.return_value = None
+        factory = npi.BenchmarkFactory(
+            bucket_name="test-bucket",
+            project_id="test-project",
+            bq_dataset_id="test-dataset",
+            iterations=5,
+            buffer_mount_path="/mnt/buffer",
+            file_cache_size_mb=4096,
+            extra_mount_options="congestion-threshold=384"
+        )
+        cmd, table_id = factory.get_benchmark_command("read_file_cache_grpc")
+        self.assertEqual(table_id, "fio_read_file_cache")
+        self.assertIn("--cache-dir=/gcsfuse-buffer/file-cache", cmd)
+        self.assertIn("--file-cache-max-size-mb=4096", cmd)
+        self.assertIn("--metadata-cache-ttl-secs=-1", cmd)
+        self.assertIn("--congestion-threshold=384", cmd)
+        self.assertIn("--keep-mount", cmd)
+
+    @patch('npi.BenchmarkFactory._get_cpu_list_for_numa_node')
+    def test_get_benchmark_command_numa_bound_with_extra_mount_options(self, mock_get_cpu):
+        mock_get_cpu.side_effect = lambda node_id: "0-15" if node_id == 0 else "16-31"
+        factory = npi.BenchmarkFactory(
+            bucket_name="test-bucket",
+            project_id="test-project",
+            bq_dataset_id="test-dataset",
+            iterations=5,
+            buffer_mount_path="/mnt/buffer",
+            extra_mount_options="max-background=512"
+        )
+        cmd, table_id = factory.get_benchmark_command("read_grpc_numa0_fio_bound")
+        self.assertEqual(table_id, "fio_read_grpc_numa0_fio_bound")
+        self.assertIn("--cpu-limit-list=0-15", cmd)
+        self.assertIn("--bind-fio", cmd)
+        self.assertIn("--max-background=512", cmd)
+
+    @patch('npi.BenchmarkFactory._get_cpu_list_for_numa_node')
+    def test_get_benchmark_command_host_info_ignores_extra_mount_options(self, mock_get_cpu):
+        mock_get_cpu.return_value = None
+        factory = npi.BenchmarkFactory(
+            bucket_name="test-bucket",
+            project_id="test-project",
+            bq_dataset_id="test-dataset",
+            iterations=1,
+            buffer_mount_path="/mnt/buffer",
+            extra_mount_options="congestion-threshold=384"
+        )
+        cmd, table_id = factory.get_benchmark_command("host_info")
+        self.assertEqual(table_id, "host_info")
+        self.assertNotIn("--gcsfuse-flags", cmd)
+        self.assertNotIn("--congestion-threshold", cmd)
+        self.assertIn("host-info-collector", cmd)
+
+
+class TestNpiMainExtraMountOptions(unittest.TestCase):
+
+    @patch('os.makedirs')
+    @patch('argparse.ArgumentParser.parse_args')
+    @patch('npi.BenchmarkFactory')
+    @patch('npi.verify_permissions', return_value=True)
+    def test_main_passes_extra_mount_options_to_factory(self, mock_verify_perms, mock_factory_class, mock_parse_args, mock_makedirs):
+        mock_args = MagicMock()
+        mock_args.benchmarks = ["read_grpc"]
+        mock_args.bucket_name = "test-bucket"
+        mock_args.mount_path = None
+        mock_args.project_id = "test-project"
+        mock_args.bq_dataset_id = "test-dataset"
+        mock_args.iterations = 5
+        mock_args.dry_run = False
+        mock_args.is_rapid_bucket = False
+        mock_args.buffer_mount_path = "/mnt/buffer"
+        mock_args.file_cache_size_mb = 2097152
+        mock_args.image_version = "latest"
+        mock_args.smoke_mode = False
+        mock_args.extra_mount_options = "congestion-threshold=384,max-background=512"
+        mock_parse_args.return_value = mock_args
+
+        mock_factory_instance = MagicMock()
+        mock_factory_instance.get_available_benchmarks.return_value = ["read_grpc"]
+        mock_factory_instance.get_benchmark_command.return_value = ("docker run ...", "test-table")
+        mock_factory_class.return_value = mock_factory_instance
+
+        with patch('npi.run_benchmark', return_value=True):
+            npi.main()
+            mock_factory_class.assert_called_once()
+            _, kwargs = mock_factory_class.call_args
+            self.assertEqual(kwargs.get("extra_mount_options"), "congestion-threshold=384,max-background=512")
+
+    def test_main_cli_help_documents_extra_mount_options(self):
+        res = subprocess.run(["python3", "npi.py", "--help"], capture_output=True, text=True, cwd=os.path.dirname(os.path.abspath(npi.__file__)))
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("--extra-mount-options", res.stdout)
+
+
+class TestOrchestratorExtraMountOptions(unittest.TestCase):
+
+    def _run_execute_target(self, target, args):
+        state = {target["name"]: {"status": "PENDING"}}
+        state_lock = MagicMock()
+        captured_cmds = []
+
+        def mock_ssh(socket_path, vm_name, zone, cmd, timeout=60):
+            captured_cmds.append(cmd)
+            return (0, "", "")
+
+        with patch('npi_orchestrator.cleanup_remote_run'), \
+             patch('npi_orchestrator.prep_vm'), \
+             patch('npi_orchestrator.run_ssh_cmd', side_effect=mock_ssh), \
+             patch('npi_orchestrator.monitor_run'):
+            npi_orchestrator.execute_target(target, args, state_lock, state)
+
+        return captured_cmds
+
+    def test_gce_target_with_target_level_extra_mount_options(self):
+        target = {
+            "name": "gce_target",
+            "type": "gce",
+            "vm_name": "vm1",
+            "zone": "us-central1-a",
+            "bucket": "gs://test-bucket",
+            "dataset": "test_dataset",
+            "buffer_mount": "/mnt/buffer",
+            "extra_mount_options": "congestion-threshold=384",
+            "has_ssd": True
+        }
+        args = MagicMock()
+        args.benchmarks = "read_grpc"
+        args.project = "test-project"
+        args.image_version = "latest"
+        args.iterations = 1
+        args.smoke_mode = False
+        args.extra_mount_options = None
+
+        cmds = self._run_execute_target(target, args)
+        triggered = [c for c in cmds if "npi.py" in c]
+        self.assertEqual(len(triggered), 1)
+        self.assertIn("--extra-mount-options=congestion-threshold=384", triggered[0])
+
+    def test_gce_target_with_cli_extra_mount_options(self):
+        target = {
+            "name": "gce_target",
+            "type": "gce",
+            "vm_name": "vm1",
+            "zone": "us-central1-a",
+            "bucket": "gs://test-bucket",
+            "dataset": "test_dataset",
+            "buffer_mount": "/mnt/buffer",
+            "has_ssd": True
+        }
+        args = MagicMock()
+        args.benchmarks = "read_grpc"
+        args.project = "test-project"
+        args.image_version = "latest"
+        args.iterations = 1
+        args.smoke_mode = False
+        args.extra_mount_options = "max-background=512"
+
+        cmds = self._run_execute_target(target, args)
+        triggered = [c for c in cmds if "npi.py" in c]
+        self.assertEqual(len(triggered), 1)
+        self.assertIn("--extra-mount-options=max-background=512", triggered[0])
+
+    def test_gce_target_with_both_target_and_cli_extra_mount_options(self):
+        target = {
+            "name": "gce_target",
+            "type": "gce",
+            "vm_name": "vm1",
+            "zone": "us-central1-a",
+            "bucket": "gs://test-bucket",
+            "dataset": "test_dataset",
+            "buffer_mount": "/mnt/buffer",
+            "extra_mount_options": "congestion-threshold=384",
+            "has_ssd": True
+        }
+        args = MagicMock()
+        args.benchmarks = "read_grpc"
+        args.project = "test-project"
+        args.image_version = "latest"
+        args.iterations = 1
+        args.smoke_mode = False
+        args.extra_mount_options = "max-background=512"
+
+        cmds = self._run_execute_target(target, args)
+        triggered = [c for c in cmds if "npi.py" in c]
+        self.assertEqual(len(triggered), 1)
+        self.assertIn("--extra-mount-options=congestion-threshold=384,max-background=512", triggered[0])
+
+    def test_gce_target_with_no_extra_mount_options(self):
+        target = {
+            "name": "gce_target",
+            "type": "gce",
+            "vm_name": "vm1",
+            "zone": "us-central1-a",
+            "bucket": "gs://test-bucket",
+            "dataset": "test_dataset",
+            "buffer_mount": "/mnt/buffer",
+            "has_ssd": True
+        }
+        args = MagicMock()
+        args.benchmarks = "read_grpc"
+        args.project = "test-project"
+        args.image_version = "latest"
+        args.iterations = 1
+        args.smoke_mode = False
+        args.extra_mount_options = None
+
+        cmds = self._run_execute_target(target, args)
+        triggered = [c for c in cmds if "npi.py" in c]
+        self.assertEqual(len(triggered), 1)
+        self.assertNotIn("--extra-mount-options", triggered[0])
+
+    def test_gke_target_with_target_level_extra_mount_options(self):
+        target = {
+            "name": "gke_target",
+            "type": "gke",
+            "vm_name": "gke-runner-vm",
+            "zone": "us-central1-a",
+            "cluster_name": "test-cluster",
+            "location": "us-central1-a",
+            "bucket": "gs://test-bucket",
+            "dataset": "test_dataset",
+            "extra_mount_options": "congestion-threshold=384",
+            "has_ssd": True
+        }
+        args = MagicMock()
+        args.benchmarks = "read_grpc"
+        args.project = "test-project"
+        args.image_version = "latest"
+        args.iterations = 1
+        args.smoke_mode = False
+        args.extra_mount_options = None
+
+        cmds = self._run_execute_target(target, args)
+        triggered = [c for c in cmds if "npi_gke.py" in c]
+        self.assertEqual(len(triggered), 1)
+        self.assertIn("--extra-mount-options=congestion-threshold=384", triggered[0])
+
+    def test_gke_target_with_cli_extra_mount_options(self):
+        target = {
+            "name": "gke_target",
+            "type": "gke",
+            "vm_name": "gke-runner-vm",
+            "zone": "us-central1-a",
+            "cluster_name": "test-cluster",
+            "location": "us-central1-a",
+            "bucket": "gs://test-bucket",
+            "dataset": "test_dataset",
+            "has_ssd": True
+        }
+        args = MagicMock()
+        args.benchmarks = "read_grpc"
+        args.project = "test-project"
+        args.image_version = "latest"
+        args.iterations = 1
+        args.smoke_mode = False
+        args.extra_mount_options = "max-background=512"
+
+        cmds = self._run_execute_target(target, args)
+        triggered = [c for c in cmds if "npi_gke.py" in c]
+        self.assertEqual(len(triggered), 1)
+        self.assertIn("--extra-mount-options=max-background=512", triggered[0])
+
+    def test_gke_target_with_both_target_and_cli_extra_mount_options(self):
+        target = {
+            "name": "gke_target",
+            "type": "gke",
+            "vm_name": "gke-runner-vm",
+            "zone": "us-central1-a",
+            "cluster_name": "test-cluster",
+            "location": "us-central1-a",
+            "bucket": "gs://test-bucket",
+            "dataset": "test_dataset",
+            "extra_mount_options": "congestion-threshold=384",
+            "has_ssd": True
+        }
+        args = MagicMock()
+        args.benchmarks = "read_grpc"
+        args.project = "test-project"
+        args.image_version = "latest"
+        args.iterations = 1
+        args.smoke_mode = False
+        args.extra_mount_options = "max-background=512"
+
+        cmds = self._run_execute_target(target, args)
+        triggered = [c for c in cmds if "npi_gke.py" in c]
+        self.assertEqual(len(triggered), 1)
+        self.assertIn("--extra-mount-options=congestion-threshold=384,max-background=512", triggered[0])
+
+    def test_gke_target_with_no_extra_mount_options(self):
+        target = {
+            "name": "gke_target",
+            "type": "gke",
+            "vm_name": "gke-runner-vm",
+            "zone": "us-central1-a",
+            "cluster_name": "test-cluster",
+            "location": "us-central1-a",
+            "bucket": "gs://test-bucket",
+            "dataset": "test_dataset",
+            "has_ssd": True
+        }
+        args = MagicMock()
+        args.benchmarks = "read_grpc"
+        args.project = "test-project"
+        args.image_version = "latest"
+        args.iterations = 1
+        args.smoke_mode = False
+        args.extra_mount_options = None
+
+        cmds = self._run_execute_target(target, args)
+        triggered = [c for c in cmds if "npi_gke.py" in c]
+        self.assertEqual(len(triggered), 1)
+        self.assertNotIn("--extra-mount-options", triggered[0])
+
+    def test_orchestrator_cli_help_documents_extra_mount_options(self):
+        res = subprocess.run(["python3", "npi_orchestrator.py", "--help"], capture_output=True, text=True, cwd=os.path.dirname(os.path.abspath(npi_orchestrator.__file__)))
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("--extra-mount-options", res.stdout)
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
### Summary
- Added support for `--extra-mount-options` in `npi.py` and propagated through `BenchmarkFactory` matching `npi_gke.py` conventions.
- Implemented `_format_extra_mount_options` to properly format comma-separated and space-separated mount options into GCSFuse flags while preserving flag prefixes and existing defaults.
- Updated `npi_orchestrator.py` to support target-level and CLI-level `extra_mount_options` for both GCE (`npi.py`) and GKE (`npi_gke.py`) targets.
- Added comprehensive unit tests in `npi_test.py` (22 new test cases covering formatting, factory Docker command assembly, CLI propagation, and orchestrator execution).

### Test Coverage
- Executed `python3 -m unittest discover -p '*test.py'` (117/117 tests passing).