### PR TITLE
feat(npi): configure 48-thread default for RAPID buckets and add explicit numjobs override

### DIFF
--- a/npi/fio/fio_benchmark_runner.py
+++ b/npi/fio/fio_benchmark_runner.py
@@ -339,11 +339,11 @@ def precreate_benchmark_directories(mount_point, fio_env, fio_config):
     else:
         logging.info("concurrent_delete.py not found. Skipping parallel cleanup.")
 
-    # 2. Pre-create nested parent directory and 112 job directories sequentially
+    # 2. Pre-create nested parent directory and job directories sequentially
     file_size = fio_env["FILE_SIZE"]
     block_size = fio_env["BLOCK_SIZE"]
     nr_files = fio_env["NR_FILES"]
-    num_jobs = int(fio_env.get("NUM_JOBS", 112))
+    num_jobs = int(fio_env.get("NUM_JOBS") or fio_env.get("NUMJOBS") or os.environ.get("NUMJOBS") or 112)
 
     nested_dir = os.path.join(target_write_dir, file_size, block_size, nr_files)
     logging.info(f"Sequentially pre-creating {num_jobs} job directories under {nested_dir}...")

--- a/npi/npi.py
+++ b/npi/npi.py
@@ -51,7 +51,7 @@ class BenchmarkFactory:
         mount_path (str): The path to an already mounted GCS bucket.
     """
 
-    def __init__(self, bucket_name, project_id, bq_dataset_id, iterations, mount_path=None, image_version="latest", buffer_mount_path=None, file_cache_size_mb=2097152, smoke_mode=False, extra_mount_options=None):
+    def __init__(self, bucket_name, project_id, bq_dataset_id, iterations, mount_path=None, image_version="latest", buffer_mount_path=None, file_cache_size_mb=2097152, smoke_mode=False, extra_mount_options=None, is_rapid_bucket=False, numjobs=None):
         """Initializes the BenchmarkFactory.
 
         Args:
@@ -65,6 +65,8 @@ class BenchmarkFactory:
             file_cache_size_mb (int): The file cache size in MB.
             smoke_mode (bool): Whether to run in smoke test mode.
             extra_mount_options (str, optional): Extra mount options for GCSFuse.
+            is_rapid_bucket (bool, optional): Whether the bucket is a RAPID bucket.
+            numjobs (int, optional): Explicit override for numjobs concurrency count.
         """
         self.bucket_name = bucket_name
         self.project_id = project_id
@@ -76,6 +78,8 @@ class BenchmarkFactory:
         self.file_cache_size_mb = file_cache_size_mb
         self.smoke_mode = smoke_mode
         self.extra_mount_options = extra_mount_options
+        self.is_rapid_bucket = is_rapid_bucket
+        self.numjobs = numjobs
         self._benchmark_definitions = self._get_benchmark_definitions()
 
     def _format_extra_mount_options(self, extra_opts):
@@ -185,7 +189,14 @@ class BenchmarkFactory:
             if extra_flags:
                 gcsfuse_flags = f"{gcsfuse_flags} {extra_flags}"
 
-        num_jobs = "2" if self.smoke_mode else "112"
+        if self.smoke_mode:
+            num_jobs = "2"
+        elif self.numjobs is not None:
+            num_jobs = str(self.numjobs)
+        elif self.is_rapid_bucket:
+            num_jobs = "48"
+        else:
+            num_jobs = "112"
         base_cmd = (
             "docker run --pull=always --network=host --privileged --rm "
             f"-e NUMJOBS={num_jobs} "
@@ -526,6 +537,12 @@ def main():
         help="If set, run in fast smoke test mode with reduced iterations and thread counts."
     )
     parser.add_argument(
+        "--numjobs",
+        type=int,
+        default=None,
+        help="Override FIO/Go-client numjobs concurrency count."
+    )
+    parser.add_argument(
         "--extra-mount-options",
         default=None,
         help="Extra mount options to pass to GCSFuse (comma-separated or space-separated, e.g., 'congestion-threshold=384,max-background=512')."
@@ -570,7 +587,9 @@ def main():
         buffer_mount_path=args.buffer_mount_path,
         file_cache_size_mb=args.file_cache_size_mb,
         smoke_mode=args.smoke_mode,
-        extra_mount_options=args.extra_mount_options
+        extra_mount_options=args.extra_mount_options,
+        is_rapid_bucket=args.is_rapid_bucket,
+        numjobs=args.numjobs
     )
 
     available_benchmarks = factory.get_available_benchmarks()

--- a/npi/npi_gke.py
+++ b/npi/npi_gke.py
@@ -38,7 +38,7 @@ def enqueue_output(out, q):
     finally:
         out.close()
 
-def create_job_spec(job_name, image, args, bucket_name, service_account, extra_flag=None, use_memory_volumes=False, is_go_client=False, node_selector=None, resources_limits=None, project_id=None, gcsfuse_sidecar_image=None):
+def create_job_spec(job_name, image, args, bucket_name, service_account, extra_flag=None, use_memory_volumes=False, is_go_client=False, node_selector=None, resources_limits=None, project_id=None, gcsfuse_sidecar_image=None, is_rapid_bucket=False):
     """Creates a Kubernetes Job spec dictionary from the template yaml."""
     script_dir = os.path.dirname(os.path.realpath(__file__))
     template_path = os.path.join(script_dir, "npi_job_spec.yaml")
@@ -54,7 +54,18 @@ def create_job_spec(job_name, image, args, bucket_name, service_account, extra_f
     pod_spec["serviceAccountName"] = service_account
 
     # Set NUMJOBS env var for FIO
-    num_jobs_val = "2" if "--numjobs=2" in args else "112"
+    if "--numjobs=2" in args:
+        num_jobs_val = "2"
+    elif any(arg.startswith("--numjobs=") for arg in args):
+        num_jobs_val = "112"
+        for arg in args:
+            if arg.startswith("--numjobs="):
+                num_jobs_val = arg.split("=", 1)[1]
+                break
+    elif is_rapid_bucket:
+        num_jobs_val = "48"
+    else:
+        num_jobs_val = "112"
     if "env" not in pod_spec["containers"][0] or not pod_spec["containers"][0]["env"]:
         pod_spec["containers"][0]["env"] = []
     pod_spec["containers"][0]["env"].append({"name": "NUMJOBS", "value": num_jobs_val})
@@ -276,13 +287,13 @@ def wait_for_job_completion(job_name, timeout_seconds=None):
 
 
 
-def run_benchmark_job(job_name, image, args_list, project_id, dataset_id, table_id, bucket_name, service_account, extra_flag=None, use_memory_volumes=False, is_go_client=False, node_selector=None, resources_limits=None, gcsfuse_sidecar_image=None):
+def run_benchmark_job(job_name, image, args_list, project_id, dataset_id, table_id, bucket_name, service_account, extra_flag=None, use_memory_volumes=False, is_go_client=False, node_selector=None, resources_limits=None, gcsfuse_sidecar_image=None, is_rapid_bucket=False):
     """Runs a benchmark job on GKE and waits for its completion."""
     # 1. Cleanup any existing job with the same name
     subprocess.run(["kubectl", "delete", "job", job_name, "--ignore-not-found=true", "--wait=true"], capture_output=True)
 
     # 2. Create Job Spec and Apply
-    job_spec = create_job_spec(job_name, image, args_list, bucket_name, service_account, extra_flag, use_memory_volumes, is_go_client, node_selector, resources_limits, project_id=project_id, gcsfuse_sidecar_image=gcsfuse_sidecar_image)
+    job_spec = create_job_spec(job_name, image, args_list, bucket_name, service_account, extra_flag, use_memory_volumes, is_go_client, node_selector, resources_limits, project_id=project_id, gcsfuse_sidecar_image=gcsfuse_sidecar_image, is_rapid_bucket=is_rapid_bucket)
     yaml_data = yaml.dump(job_spec)
 
     print(f"--- Submitting Kubernetes Job: {job_name} ---")
@@ -455,6 +466,12 @@ def main():
         action="store_true",
         help="If set, run in fast smoke test mode with reduced iterations and thread counts."
     )
+    parser.add_argument(
+        "--numjobs",
+        type=int,
+        default=None,
+        help="Override FIO/Go-client numjobs concurrency count."
+    )
     
     args = parser.parse_args()
 
@@ -579,6 +596,10 @@ def main():
                 f"--bq-table-id={bq_table_id}",
                 f"--bucket-name={args.bucket_name}"
             ]
+            if args.numjobs is not None:
+                cmd_args.append(f"--numjobs={args.numjobs}")
+            elif args.is_rapid_bucket:
+                cmd_args.append("--numjobs=48")
         else:
             cmd_args = [
                 f"--iterations={target_iterations}",
@@ -589,6 +610,10 @@ def main():
             ]
             if args.smoke_mode:
                 cmd_args.append("--numjobs=2")
+            elif args.numjobs is not None:
+                cmd_args.append(f"--numjobs={args.numjobs}")
+            elif args.is_rapid_bucket:
+                cmd_args.append("--numjobs=48")
             
         if runner_args:
             cmd_args.append(runner_args)
@@ -602,7 +627,7 @@ def main():
                 combined_extra_flag = args.extra_mount_options
 
         if args.dry_run:
-            job_spec = create_job_spec(job_name, image, cmd_args, args.bucket_name, args.kubernetes_service_account, combined_extra_flag, args.use_memory_volumes, is_go_client, node_selector, resources_limits, gcsfuse_sidecar_image=args.gcsfuse_sidecar_image)
+            job_spec = create_job_spec(job_name, image, cmd_args, args.bucket_name, args.kubernetes_service_account, combined_extra_flag, args.use_memory_volumes, is_go_client, node_selector, resources_limits, gcsfuse_sidecar_image=args.gcsfuse_sidecar_image, is_rapid_bucket=args.is_rapid_bucket)
             print(f" - {full_bench_name}")
             print(f"   Job Name: {job_name}")
             print(f"   Image: {image}")
@@ -627,7 +652,8 @@ def main():
                 is_go_client=is_go_client,
                 node_selector=node_selector,
                 resources_limits=resources_limits,
-                gcsfuse_sidecar_image=args.gcsfuse_sidecar_image
+                gcsfuse_sidecar_image=args.gcsfuse_sidecar_image,
+                is_rapid_bucket=args.is_rapid_bucket
             )
 
             if not success:

--- a/npi/npi_gke_test.py
+++ b/npi/npi_gke_test.py
@@ -124,6 +124,150 @@ class TestCreateJobSpec(unittest.TestCase):
         self.assertIn("limits", container["resources"])
         self.assertEqual(container["resources"]["limits"]["cpu"], "4")
 
+    @patch("npi_gke.yaml.safe_load")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_create_job_spec_numjobs_rapid_bucket(self, mock_file, mock_yaml_load):
+        template_spec = {
+            "metadata": {"name": "template"},
+            "spec": {
+                "template": {
+                    "metadata": {"labels": {"app": "test"}},
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "benchmark",
+                                "image": "placeholder",
+                                "args": []
+                            }
+                        ],
+                        "volumes": []
+                    }
+                }
+            }
+        }
+        mock_yaml_load.return_value = template_spec
+
+        res = npi_gke.create_job_spec(
+            job_name="test-job",
+            image="test-image",
+            args=["--iterations=1"],
+            bucket_name="test-bucket",
+            service_account="test-sa",
+            is_rapid_bucket=True
+        )
+
+        container = res["spec"]["template"]["spec"]["containers"][0]
+        env_vars = {e["name"]: e["value"] for e in container.get("env", [])}
+        self.assertEqual(env_vars.get("NUMJOBS"), "48")
+
+    @patch("npi_gke.yaml.safe_load")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_create_job_spec_numjobs_standard(self, mock_file, mock_yaml_load):
+        template_spec = {
+            "metadata": {"name": "template"},
+            "spec": {
+                "template": {
+                    "metadata": {"labels": {"app": "test"}},
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "benchmark",
+                                "image": "placeholder",
+                                "args": []
+                            }
+                        ],
+                        "volumes": []
+                    }
+                }
+            }
+        }
+        mock_yaml_load.return_value = template_spec
+
+        res = npi_gke.create_job_spec(
+            job_name="test-job",
+            image="test-image",
+            args=["--iterations=1"],
+            bucket_name="test-bucket",
+            service_account="test-sa",
+            is_rapid_bucket=False
+        )
+
+        container = res["spec"]["template"]["spec"]["containers"][0]
+        env_vars = {e["name"]: e["value"] for e in container.get("env", [])}
+        self.assertEqual(env_vars.get("NUMJOBS"), "112")
+
+    @patch("npi_gke.yaml.safe_load")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_create_job_spec_numjobs_smoke_mode(self, mock_file, mock_yaml_load):
+        template_spec = {
+            "metadata": {"name": "template"},
+            "spec": {
+                "template": {
+                    "metadata": {"labels": {"app": "test"}},
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "benchmark",
+                                "image": "placeholder",
+                                "args": []
+                            }
+                        ],
+                        "volumes": []
+                    }
+                }
+            }
+        }
+        mock_yaml_load.return_value = template_spec
+
+        res = npi_gke.create_job_spec(
+            job_name="test-job",
+            image="test-image",
+            args=["--numjobs=2"],
+            bucket_name="test-bucket",
+            service_account="test-sa",
+            is_rapid_bucket=True
+        )
+
+        container = res["spec"]["template"]["spec"]["containers"][0]
+        env_vars = {e["name"]: e["value"] for e in container.get("env", [])}
+        self.assertEqual(env_vars.get("NUMJOBS"), "2")
+
+    @patch("npi_gke.yaml.safe_load")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_create_job_spec_numjobs_explicit_override(self, mock_file, mock_yaml_load):
+        template_spec = {
+            "metadata": {"name": "template"},
+            "spec": {
+                "template": {
+                    "metadata": {"labels": {"app": "test"}},
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "benchmark",
+                                "image": "placeholder",
+                                "args": []
+                            }
+                        ],
+                        "volumes": []
+                    }
+                }
+            }
+        }
+        mock_yaml_load.return_value = template_spec
+
+        res = npi_gke.create_job_spec(
+            job_name="test-job",
+            image="test-image",
+            args=["--numjobs=64"],
+            bucket_name="test-bucket",
+            service_account="test-sa",
+            is_rapid_bucket=True
+        )
+
+        container = res["spec"]["template"]["spec"]["containers"][0]
+        env_vars = {e["name"]: e["value"] for e in container.get("env", [])}
+        self.assertEqual(env_vars.get("NUMJOBS"), "64")
+
 class TestGKEUtils(unittest.TestCase):
 
     @patch("builtins.open", new_callable=mock_open, read_data="MemTotal:        65536000 kB\n")

--- a/npi/npi_test.py
+++ b/npi/npi_test.py
@@ -42,8 +42,41 @@ class TestBenchmarkFactory(unittest.TestCase):
         
         cmd, table_id = factory.get_benchmark_command("read_http1")
         self.assertIn("-v /mnt/buffer:/gcsfuse-buffer", cmd)
+        self.assertIn("-e NUMJOBS=112", cmd)
         self.assertIn("--temp-dir=/gcsfuse-buffer/write", cmd)
         self.assertIn("us-docker.pkg.dev/test-project/gcsfuse-benchmarks/fio-read-benchmark:latest", cmd)
+
+    @patch('npi.BenchmarkFactory._get_cpu_list_for_numa_node')
+    def test_get_benchmark_command_rapid_bucket(self, mock_get_cpu):
+        mock_get_cpu.return_value = None
+        
+        factory = npi.BenchmarkFactory(
+            bucket_name="test-bucket",
+            project_id="test-project",
+            bq_dataset_id="test-dataset",
+            iterations=5,
+            buffer_mount_path="/mnt/buffer",
+            is_rapid_bucket=True
+        )
+        
+        cmd, table_id = factory.get_benchmark_command("read_grpc")
+        self.assertIn("-e NUMJOBS=48", cmd)
+
+    @patch('npi.BenchmarkFactory._get_cpu_list_for_numa_node')
+    def test_get_benchmark_command_numjobs_override(self, mock_get_cpu):
+        mock_get_cpu.return_value = None
+        
+        factory = npi.BenchmarkFactory(
+            bucket_name="test-bucket",
+            project_id="test-project",
+            bq_dataset_id="test-dataset",
+            iterations=5,
+            buffer_mount_path="/mnt/buffer",
+            numjobs=64
+        )
+        
+        cmd, table_id = factory.get_benchmark_command("read_http1")
+        self.assertIn("-e NUMJOBS=64", cmd)
 
     @patch('npi.BenchmarkFactory._get_cpu_list_for_numa_node')
     def test_get_benchmark_command_file_cache(self, mock_get_cpu):


### PR DESCRIPTION
### Summary

- Sets `NUMJOBS=48` concurrency for Zonal RAPID buckets across GCE (`npi.py`) and GKE (`npi_gke.py`) benchmark runners, while preserving `NUMJOBS=112` default for standard Regional buckets.
- Introduces `--numjobs` CLI argument in `npi.py` and `npi_gke.py` to allow custom job concurrency overrides.
- Updates FIO benchmark runner (`fio_benchmark_runner.py`) to dynamically resolve `num_jobs` from environment variables (`NUM_JOBS`, `NUMJOBS`) when pre-creating benchmark directories.
- Adds comprehensive unit tests in `npi_test.py` and `npi_gke_test.py` covering standard, RAPID, smoke mode, and explicit `--numjobs` overrides.

### Testing
- Ran unit test suite (`python3 -m unittest discover -p "*_test.py"`) — all 123 tests passed.