### PR TITLE
fix(ci): resolve Zizmor security findings and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/deploy-cloud-run-services.yaml
+++ b/.github/workflows/deploy-cloud-run-services.yaml
@@ -35,7 +35,8 @@ concurrency:
 
 jobs:
   test:
-    permissions: read-all
+    permissions:
+      contents: read
     name: Unit, Stress & Artifact Verification Tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-cloud-run-services.yaml
+++ b/.github/workflows/deploy-cloud-run-services.yaml
@@ -35,14 +35,17 @@ concurrency:
 
 jobs:
   test:
+    permissions: read-all
     name: Unit, Stress & Artifact Verification Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   build:
-    permissions: read-all
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,11 +8,14 @@ on:
 
 jobs:
   build:
+    permissions: read-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+        with:
+          persist-credentials: false
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: "3.10"
       - name: Install dependencies

--- a/.github/workflows/npi.yaml
+++ b/.github/workflows/npi.yaml
@@ -8,11 +8,14 @@ on:
 
 jobs:
   build:
+    permissions: read-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
+        with:
+          persist-credentials: false
       - name: Set up Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3
         with:
           python-version: "3.14"
       - name: Run tests with unittest

--- a/.github/workflows/npi.yaml
+++ b/.github/workflows/npi.yaml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   build:
-    permissions: read-all
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3


### PR DESCRIPTION
This commit addresses the security misconfigurations flagged by Zizmor 
as part of the Cloud CISO rollout for GitHub Actions security. 

Specific changes include:
- Pinned third-party GitHub Actions to specific commit hashes to 
  prevent supply-chain attacks (unpinned-uses).
- Added `persist-credentials: false` to checkout steps to prevent 
  accidental token leakage (artipacked).
- Added explicit `permissions: read-all` blocks to jobs to enforce 
  the principle of least privilege (excessive-permissions).
- Created `.github/dependabot.yml` configured for `github-actions` 
  to automatically maintain and update the newly pinned actions.

Bug: [b/555796395](b/555796395)
