### PR TITLE
feat(reservation-cleaner): change default cron schedule to run daily

### DIFF
--- a/cloud-run-services/README.md
+++ b/cloud-run-services/README.md
@@ -56,7 +56,7 @@ flowchart TD
     subgraph INVOCATION ["1. INVOCATION & SCHEDULING TIER (Cloud Scheduler)"]
         direction TB
         SCHED_CS["<b>Cloud Scheduler: cluster-scaler</b><br/>Cron: 0 2 * * * (Daily 02:00 UTC)<br/>OIDC Token (Service Account)"]:::schedStyle
-        SCHED_RC["<b>Cloud Scheduler: reservation-cleaner</b><br/>Cron: 0 0 1 * * (Monthly 1st 00:00 UTC)<br/>OIDC Token (Service Account)"]:::schedStyle
+        SCHED_RC["<b>Cloud Scheduler: reservation-cleaner</b><br/>Cron: 0 0 * * * (Daily 00:00 UTC)<br/>OIDC Token (Service Account)"]:::schedStyle
         SCHED_VM["<b>Cloud Scheduler: vm-stopper</b><br/>Cron: 0 20 * * * (Daily 20:00 UTC)<br/>OIDC Token (Service Account)"]:::schedStyle
     end
 
@@ -109,7 +109,7 @@ flowchart TD
 | :--- | :--- | :--- | :--- |
 | **Target Infrastructure** | Google Kubernetes Engine (GKE) Clusters & Node Pools | Google Compute Engine (GCE) Reservations | Google Compute Engine (GCE) VM Instances |
 | **Primary Remediation Action** | Resizes idle node pools to size 0 (sets autoscaling min to 0) | Deletes stale or abandoned compute reservations | Stops idle running VMs (optional deletion of long-stopped VMs) |
-| **Default Schedule** | Daily at 02:00 UTC (`0 2 * * *`) | Monthly on the 1st at 00:00 UTC (`0 0 1 * *`) | Daily at 20:00 UTC (`0 20 * * *`) |
+| **Default Schedule** | Daily at 02:00 UTC (`0 2 * * *`) | Daily at 00:00 UTC (`0 0 * * *`) | Daily at 20:00 UTC (`0 20 * * *`) |
 | **Idle Detection Method** | K8s API pod inspection across non-system namespaces | Cloud Monitoring metrics (`compute.googleapis.com/reservation/used`) | Cloud Logging OSLogin audit events and instance metadata events |
 | **Idle Threshold Parameter** | `idle_days_threshold` (Default: `7` days) | `delete_idle_days` (Default: `60` days) | `idle_days_threshold` (Default: `7` days) |
 | **Lifecycle State Tracking** | Stamped GKE cluster labels: `idle_since=YYYY-MM-DD` | Historical utilization lookback (Default: `730` days) | Instance `creationTimestamp` + Cloud Logging timestamp |
@@ -332,7 +332,7 @@ The suite supports three distinct deployment workflows tailored to different ope
 | | `--skip-tests` | `SKIP_TESTS` | `false` | Bypass Stage 1 pre-deployment offline unit test gating |
 | | `--repo-name` | `REPO_NAME` | `gcsfuse-tools` | Artifact Registry Docker repository name |
 | | `--cluster-scaler-schedule` | `CLUSTER_SCALER_SCHEDULE` | `"0 2 * * *"` | Cron schedule for `cluster-scaler` (Daily at 02:00 UTC) |
-| | `--cleaner-schedule` | `CLEANER_SCHEDULE` | `"0 0 1 * *"` | Cron schedule for `gcsfuse-reservation-cleaner` (Monthly 1st 00:00 UTC) |
+| | `--cleaner-schedule` | `CLEANER_SCHEDULE` | `"0 0 * * *"` | Cron schedule for `gcsfuse-reservation-cleaner` (Daily 00:00 UTC) |
 | | `--vm-stopper-schedule` | `VM_STOPPER_SCHEDULE` | `"0 20 * * *"` | Cron schedule for `vm-stopper` (Daily at 20:00 UTC) |
 | `-t` | `--threshold` | `IDLE_DAYS_THRESHOLD` | `7` | Days of inactivity before resizing idle GKE node pools to 0 |
 | `-h` | `--help` | - | - | Displays usage instructions and exits with code 0 |
@@ -410,7 +410,7 @@ Before compiling container images or mutating GCP resources, Stage 1 executes al
 | `_IMAGE_TAG` | `"latest"` | Tag applied to compiled container images. |
 | `_DRY_RUN` | `"false"` | Global dry-run flag passed to Cloud Run environment and scheduler payloads. |
 | `_CLUSTER_SCALER_SCHEDULE` | `"0 2 * * *"` | Cron expression for `cluster-scaler` (Daily at 02:00 UTC). |
-| `_CLEANER_SCHEDULE` | `"0 0 1 * *"` | Cron expression for `gcsfuse-reservation-cleaner` (Monthly 1st 00:00 UTC). |
+| `_CLEANER_SCHEDULE` | `"0 0 * * *"` | Cron expression for `gcsfuse-reservation-cleaner` (Daily 00:00 UTC). |
 | `_VM_STOPPER_SCHEDULE` | `"0 20 * * *"` | Cron expression for `vm-stopper` (Daily at 20:00 UTC). |
 | `_IDLE_DAYS_THRESHOLD` | `"7"` | Inactivity threshold in days before scaling idle GKE node pools. |
 | `_CLUSTER_SCALER_SA` | `"cluster-scaler-sa"` | Name of the Runtime Service Account for `cluster-scaler`. |
@@ -488,7 +488,7 @@ enable_vm_stopper          = true
 
 # Custom schedules
 cluster_scaler_schedule      = "0 2 * * *"
-reservation_cleaner_schedule = "0 0 1 * *"
+reservation_cleaner_schedule = "0 0 * * *"
 vm_stopper_schedule          = "0 20 * * *"
 ```
 

--- a/cloud-run-services/cloudbuild.yaml
+++ b/cloud-run-services/cloudbuild.yaml
@@ -336,7 +336,7 @@ substitutions:
   _IMAGE_TAG: 'latest'
   _DRY_RUN: 'false'
   _CLUSTER_SCALER_SCHEDULE: '0 2 * * *'
-  _CLEANER_SCHEDULE: '0 0 1 * *'
+  _CLEANER_SCHEDULE: '0 0 * * *'
   _VM_STOPPER_SCHEDULE: '0 20 * * *'
   _IDLE_DAYS_THRESHOLD: '7'
   _CLUSTER_SCALER_SA: 'cluster-scaler-sa'

--- a/cloud-run-services/deploy_all.sh
+++ b/cloud-run-services/deploy_all.sh
@@ -106,7 +106,7 @@ NO_GRANT_ROLES="${NO_GRANT_ROLES:-false}"
 
 # Cron Schedules
 CLUSTER_SCALER_SCHEDULE="${CLUSTER_SCALER_SCHEDULE:-0 2 * * *}"
-CLEANER_SCHEDULE="${CLEANER_SCHEDULE:-0 0 1 * *}"
+CLEANER_SCHEDULE="${CLEANER_SCHEDULE:-0 0 * * *}"
 VM_STOPPER_SCHEDULE="${VM_STOPPER_SCHEDULE:-0 20 * * *}"
 
 # Parameters
@@ -142,7 +142,7 @@ Options:
 
 Schedule Customization:
       --cluster-scaler-schedule CRON    Cron schedule for cluster-scaler (Default: "0 2 * * *")
-      --cleaner-schedule CRON           Cron schedule for reservation-cleaner (Default: "0 0 1 * *")
+      --cleaner-schedule CRON           Cron schedule for reservation-cleaner (Default: "0 0 * * *")
       --vm-stopper-schedule CRON        Cron schedule for vm-stopper (Default: "0 20 * * *")
   -t, --threshold DAYS                  Idle days threshold for cluster-scaler (Default: 7)
 

--- a/cloud-run-services/gcsfuse-reservation-cleaner/README.md
+++ b/cloud-run-services/gcsfuse-reservation-cleaner/README.md
@@ -27,7 +27,7 @@ The service follows a decoupled three-tier serverless architecture:
 ```mermaid
 flowchart TD
     subgraph Invocation Tier
-        Sched[Cloud Scheduler\nCron: 0 0 1 * *]
+        Sched[Cloud Scheduler\nCron: 0 0 * * *]
     end
 
     subgraph Execution Tier
@@ -191,7 +191,7 @@ Usage: deploy.sh [OPTIONS]
 Options:
   -p, --project PROJECT_ID          Target GCP Project ID (Required if not set via PROJECT_ID env var)
   -r, --region REGION               GCP Region for Cloud Run & Scheduler (Default: us-central1)
-  -s, --schedule CRON_SCHEDULE      Cron schedule expression (Default: "0 0 1 * *")
+  -s, --schedule CRON_SCHEDULE      Cron schedule expression (Default: "0 0 * * *")
   -a, --service-account EMAIL       Runtime Service Account email for Cloud Run
       --scheduler-sa EMAIL          Invocation Service Account email for Cloud Scheduler
   -d, --dry-run                     Configure default scheduler payload in dry-run mode (Default: false)

--- a/cloud-run-services/gcsfuse-reservation-cleaner/deploy.sh
+++ b/cloud-run-services/gcsfuse-reservation-cleaner/deploy.sh
@@ -41,7 +41,7 @@ APP_NAME="gcsfuse-reservation-cleaner"
 REPO_NAME="${REPO_NAME:-gcsfuse-tools}"
 SERVICE_NAME="${SERVICE_NAME:-${APP_NAME}}"
 SCHEDULE_NAME="${SCHEDULE_NAME:-${APP_NAME}-scheduler}"
-CRON_SCHEDULE="${CRON_SCHEDULE:-0 0 1 * *}"
+CRON_SCHEDULE="${CRON_SCHEDULE:-0 0 * * *}"
 
 # Service Accounts
 RUNNER_SA_NAME="${RUNNER_SA_NAME:-gcsfuse-res-cleaner-sa}"

--- a/cloud-run-services/terraform/README.md
+++ b/cloud-run-services/terraform/README.md
@@ -102,7 +102,7 @@ terraform apply tfplan
 | `cluster_scaler_scheduler_sa_email` | `string` | `""` | No | Existing Invoker SA email (used when `create_service_accounts = false`). |
 | `reservation_cleaner_service_name` | `string` | `"gcsfuse-reservation-cleaner"` | No | Cloud Run service name for GCE Reservation Cleaner. |
 | `reservation_cleaner_schedule_name` | `string` | `"gcsfuse-reservation-cleaner-scheduler"` | No | Cloud Scheduler job name for GCE Reservation Cleaner. |
-| `reservation_cleaner_schedule` | `string` | `"0 0 1 * *"` | No | Cron schedule for Reservation Cleaner (Monthly on 1st at 00:00 UTC). |
+| `reservation_cleaner_schedule` | `string` | `"0 0 * * *"` | No | Cron schedule for Reservation Cleaner (Daily at 00:00 UTC). |
 | `reservation_cleaner_image` | `string` | `""` | No | Container image URL override for Reservation Cleaner. |
 | `reservation_cleaner_delete_idle_days` | `number` | `60` | No | Days of continuous 0-utilization before an unused reservation is deleted. |
 | `reservation_cleaner_delete_never_used` | `bool` | `true` | No | Whether to delete reservations never used since creation. |

--- a/cloud-run-services/terraform/terraform.tfvars.example
+++ b/cloud-run-services/terraform/terraform.tfvars.example
@@ -58,7 +58,7 @@ cluster_scaler_max_workers         = 10
 # ==============================================================================
 reservation_cleaner_service_name      = "gcsfuse-reservation-cleaner"
 reservation_cleaner_schedule_name     = "gcsfuse-reservation-cleaner-scheduler"
-reservation_cleaner_schedule          = "0 0 1 * *" # Monthly on 1st at 00:00 UTC
+reservation_cleaner_schedule          = "0 0 * * *" # Daily at 00:00 UTC
 reservation_cleaner_delete_idle_days  = 60          # Continuous 0-utilization days before deletion
 reservation_cleaner_delete_never_used = true        # Delete reservations never utilized since creation
 reservation_cleaner_max_age_days      = 180         # Maximum reservation lifetime in days

--- a/cloud-run-services/terraform/variables.tf
+++ b/cloud-run-services/terraform/variables.tf
@@ -149,8 +149,8 @@ variable "reservation_cleaner_schedule_name" {
 
 variable "reservation_cleaner_schedule" {
   type        = string
-  description = "Cron schedule expression for GCE Reservation Cleaner (default: monthly on 1st at 00:00 UTC)."
-  default     = "0 0 1 * *"
+  description = "Cron schedule expression for GCE Reservation Cleaner (default: daily at 00:00 UTC)."
+  default     = "0 0 * * *"
 }
 
 variable "reservation_cleaner_image" {

--- a/cloud-run-services/verify_deployment_artifacts.py
+++ b/cloud-run-services/verify_deployment_artifacts.py
@@ -642,7 +642,7 @@ class TestCloudBuildConfig(unittest.TestCase):
             "_IMAGE_TAG": "latest",
             "_DRY_RUN": "false",
             "_CLUSTER_SCALER_SCHEDULE": "0 2 * * *",
-            "_CLEANER_SCHEDULE": "0 0 1 * *",
+            "_CLEANER_SCHEDULE": "0 0 * * *",
             "_VM_STOPPER_SCHEDULE": "0 20 * * *",
             "_IDLE_DAYS_THRESHOLD": "7",
             "_CLUSTER_SCALER_SA": "cluster-scaler-sa",


### PR DESCRIPTION
### Summary

Updates the default Cloud Scheduler cron expression for `gcsfuse-reservation-cleaner` from monthly on the 1st (`0 0 1 * *`) to daily at midnight UTC (`0 0 * * *`).

### Changes

- **Deploy Scripts**:
  - `cloud-run-services/gcsfuse-reservation-cleaner/deploy.sh`: Updated default `CRON_SCHEDULE` to `0 0 * * *`.
  - `cloud-run-services/deploy_all.sh`: Updated default `CLEANER_SCHEDULE` and CLI help text to `0 0 * * *`.
- **Cloud Build**:
  - `cloud-run-services/cloudbuild.yaml`: Updated `_CLEANER_SCHEDULE` substitution default to `0 0 * * *`.
- **Terraform**:
  - `cloud-run-services/terraform/variables.tf`: Updated `reservation_cleaner_schedule` variable default to `0 0 * * *` and description to daily.
  - `cloud-run-services/terraform/terraform.tfvars.example`: Updated default schedule to `0 0 * * *`.
  - `cloud-run-services/terraform/README.md`: Updated variable reference table.
- **Documentation & Verification**:
  - `cloud-run-services/README.md`: Updated architecture diagrams, comparison matrix, CLI flags, Cloud Build substitutions, and Terraform snippet.
  - `cloud-run-services/gcsfuse-reservation-cleaner/README.md`: Updated architecture diagram and CLI help reference.
  - `cloud-run-services/verify_deployment_artifacts.py`: Updated test assertion for `_CLEANER_SCHEDULE`.

### Verification

- Ran `verify_deployment_artifacts.py` (30/30 passed)
- Ran `gcsfuse-reservation-cleaner` unit tests (43/43 passed)
- Ran `verify_stress_tests.py` (11/11 passed)