### PR TITLE
feat(vm-stopper): detect direct and VS Code SSH sessions using Cloud Monitoring network metrics

### DIFF
--- a/cloud-run-services/cloudbuild.yaml
+++ b/cloud-run-services/cloudbuild.yaml
@@ -168,7 +168,7 @@ steps:
         declare -A SA_ROLES=(
           ["${_CLUSTER_SCALER_SA}"]="roles/container.admin roles/logging.logWriter"
           ["${_CLEANER_SA}"]="roles/compute.admin roles/monitoring.viewer roles/logging.logWriter"
-          ["${_VM_STOPPER_SA}"]="roles/compute.instanceAdmin.v1 roles/logging.viewer roles/logging.logWriter"
+          ["${_VM_STOPPER_SA}"]="roles/compute.instanceAdmin.v1 roles/logging.viewer roles/logging.logWriter roles/monitoring.viewer"
         )
         SCHED_SAS=("${_CLUSTER_SCALER_SCHEDULER_SA}" "${_CLEANER_SCHEDULER_SA}" "${_VM_STOPPER_SCHEDULER_SA}")
 

--- a/cloud-run-services/deploy_all.sh
+++ b/cloud-run-services/deploy_all.sh
@@ -382,7 +382,7 @@ check_prerequisites_and_apis() {
         apis+=("compute.googleapis.com" "monitoring.googleapis.com")
         ;;
       vm-stopper)
-        apis+=("compute.googleapis.com")
+        apis+=("compute.googleapis.com" "monitoring.googleapis.com")
         ;;
     esac
   done
@@ -604,7 +604,7 @@ deploy_service() {
     vm-stopper)
       default_runner_sa_name="vm-stopper-sa"
       default_sched_sa_name="vm-stopper-sched"
-      iam_roles=("roles/compute.instanceAdmin.v1" "roles/logging.viewer" "roles/logging.logWriter")
+      iam_roles=("roles/compute.instanceAdmin.v1" "roles/logging.viewer" "roles/logging.logWriter" "roles/monitoring.viewer")
       cron_schedule="${VM_STOPPER_SCHEDULE}"
       ;;
   esac

--- a/cloud-run-services/terraform/main.tf
+++ b/cloud-run-services/terraform/main.tf
@@ -65,6 +65,7 @@ locals {
     "roles/compute.instanceAdmin.v1",
     "roles/logging.viewer",
     "roles/logging.logWriter",
+    "roles/monitoring.viewer",
   ]
 }
 

--- a/cloud-run-services/verify_stress_tests.py
+++ b/cloud-run-services/verify_stress_tests.py
@@ -662,6 +662,7 @@ class EmpiricalGCEVMStopperTests(unittest.TestCase):
         """Verify transitional statuses, young VMs, and multi-threaded sweep concurrency."""
         now_utc = datetime.datetime.now(timezone.utc)
         mock_client = MagicMock(spec=GCEClient)
+        mock_client.has_network_activity.return_value = (False, 0)
         processor = VMProcessor(config=self.config, gce_client=mock_client)
 
         # 1. Transitional VM statuses

--- a/cloud-run-services/verify_stress_tests.py
+++ b/cloud-run-services/verify_stress_tests.py
@@ -26,10 +26,20 @@ from __future__ import annotations
 
 import datetime
 from datetime import timezone
+from pathlib import Path
 import random
 import sys
 import unittest
 from unittest.mock import MagicMock, patch
+
+# Bootstrap sys.path so the test script runs standalone without external PYTHONPATH
+_REPO_ROOT = Path(__file__).resolve().parent
+for _sub in ["cluster-scaler", "gcsfuse-reservation-cleaner", "vm-stopper"]:
+    _p = str(_REPO_ROOT / _sub)
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
 # --- Service 1 Imports: GKE Cluster Scaler ---
 from scaler.config import ScalerConfig

--- a/cloud-run-services/vm-stopper/deploy.sh
+++ b/cloud-run-services/vm-stopper/deploy.sh
@@ -212,6 +212,7 @@ enable_apis() {
     artifactregistry.googleapis.com \
     compute.googleapis.com \
     logging.googleapis.com \
+    monitoring.googleapis.com \
     iam.googleapis.com \
     --project "${PROJECT_ID}"
   log "Required APIs enabled/verified."
@@ -366,7 +367,7 @@ setup_service_accounts() {
   fi
 
   # Verify and assign roles to Runner SA
-  for role in "roles/compute.instanceAdmin.v1" "roles/logging.viewer" "roles/logging.logWriter"; do
+  for role in "roles/compute.instanceAdmin.v1" "roles/logging.viewer" "roles/logging.logWriter" "roles/monitoring.viewer"; do
     ensure_project_iam_role "${PROJECT_ID}" "serviceAccount:${RUNNER_SA_EMAIL}" "${role}"
   done
 

--- a/cloud-run-services/vm-stopper/requirements.txt
+++ b/cloud-run-services/vm-stopper/requirements.txt
@@ -3,5 +3,6 @@ functions-framework>=3.5.0
 google-auth>=2.16.0
 google-cloud-compute>=1.14.0
 google-cloud-logging>=3.8.0
+google-cloud-monitoring>=2.14.0
 gunicorn>=20.1.0
 python-dateutil>=2.8.2

--- a/cloud-run-services/vm-stopper/stopper/config.py
+++ b/cloud-run-services/vm-stopper/stopper/config.py
@@ -124,20 +124,37 @@ def _parse_bytes(val: Any, default: int = 10485760) -> int:
                 pass
         val_upper = val_clean.upper()
         multiplier = 1
-        if val_upper.endswith("GIB") or val_upper.endswith("GB") or val_upper.endswith("G"):
+        num_part = val_upper
+        if val_upper.endswith("GIB"):
             multiplier = 1024 * 1024 * 1024
-            num_part = val_upper.rstrip("GIB").rstrip("GB").rstrip("G").strip()
-        elif val_upper.endswith("MIB") or val_upper.endswith("MB") or val_upper.endswith("M"):
+            num_part = val_upper[:-3].strip()
+        elif val_upper.endswith("GB"):
+            multiplier = 1024 * 1024 * 1024
+            num_part = val_upper[:-2].strip()
+        elif val_upper.endswith("G"):
+            multiplier = 1024 * 1024 * 1024
+            num_part = val_upper[:-1].strip()
+        elif val_upper.endswith("MIB"):
             multiplier = 1024 * 1024
-            num_part = val_upper.rstrip("MIB").rstrip("MB").rstrip("M").strip()
-        elif val_upper.endswith("KIB") or val_upper.endswith("KB") or val_upper.endswith("K"):
+            num_part = val_upper[:-3].strip()
+        elif val_upper.endswith("MB"):
+            multiplier = 1024 * 1024
+            num_part = val_upper[:-2].strip()
+        elif val_upper.endswith("M"):
+            multiplier = 1024 * 1024
+            num_part = val_upper[:-1].strip()
+        elif val_upper.endswith("KIB"):
             multiplier = 1024
-            num_part = val_upper.rstrip("KIB").rstrip("KB").rstrip("K").strip()
+            num_part = val_upper[:-3].strip()
+        elif val_upper.endswith("KB"):
+            multiplier = 1024
+            num_part = val_upper[:-2].strip()
+        elif val_upper.endswith("K"):
+            multiplier = 1024
+            num_part = val_upper[:-1].strip()
         elif val_upper.endswith("B"):
             multiplier = 1
-            num_part = val_upper.rstrip("B").strip()
-        else:
-            num_part = val_upper
+            num_part = val_upper[:-1].strip()
         try:
             return int(float(num_part) * multiplier)
         except (ValueError, TypeError):

--- a/cloud-run-services/vm-stopper/stopper/config.py
+++ b/cloud-run-services/vm-stopper/stopper/config.py
@@ -105,6 +105,48 @@ def _parse_float(val: Any, default: float, min_val: float = 0.0) -> float:
         return default
 
 
+def _parse_bytes(val: Any, default: int = 10485760) -> int:
+    """Parse byte value supporting integers, strings, and unit suffixes (B, KB, MB, GB)."""
+    if val is None:
+        return default
+    if isinstance(val, bool):
+        return default
+    if isinstance(val, (int, float)):
+        return int(val)
+    if isinstance(val, str):
+        val_clean = val.strip()
+        if not val_clean:
+            return default
+        if val_clean.startswith("-"):
+            try:
+                return int(float(val_clean))
+            except (ValueError, TypeError):
+                pass
+        val_upper = val_clean.upper()
+        multiplier = 1
+        if val_upper.endswith("GIB") or val_upper.endswith("GB") or val_upper.endswith("G"):
+            multiplier = 1024 * 1024 * 1024
+            num_part = val_upper.rstrip("GIB").rstrip("GB").rstrip("G").strip()
+        elif val_upper.endswith("MIB") or val_upper.endswith("MB") or val_upper.endswith("M"):
+            multiplier = 1024 * 1024
+            num_part = val_upper.rstrip("MIB").rstrip("MB").rstrip("M").strip()
+        elif val_upper.endswith("KIB") or val_upper.endswith("KB") or val_upper.endswith("K"):
+            multiplier = 1024
+            num_part = val_upper.rstrip("KIB").rstrip("KB").rstrip("K").strip()
+        elif val_upper.endswith("B"):
+            multiplier = 1
+            num_part = val_upper.rstrip("B").strip()
+        else:
+            num_part = val_upper
+        try:
+            return int(float(num_part) * multiplier)
+        except (ValueError, TypeError):
+            logger.warning("Failed to parse byte string '%s', falling back to default %d", val, default)
+            return default
+    return default
+
+
+
 def _parse_list(val: Any, default: Optional[List[str]] = None) -> List[str]:
     """Parse list of strings from list, JSON string, or comma-separated string."""
     if default is None:
@@ -178,6 +220,9 @@ class StopperConfig:
     cloud_logging_rate_limit: int = 40
     cloud_logging_max_retries: int = 4
     cloud_logging_retry_backoff: float = 2.0
+    network_bytes_threshold: int = 10485760
+    network_lookback_hours: Optional[int] = None
+    enable_network_monitoring: bool = True
 
     def validate(self) -> None:
         """Validate configuration integrity."""
@@ -200,6 +245,11 @@ class StopperConfig:
             raise ValueError(f"cloud_logging_max_retries must be >= 0, got {self.cloud_logging_max_retries}")
         if self.cloud_logging_retry_backoff < 0:
             raise ValueError(f"cloud_logging_retry_backoff must be >= 0, got {self.cloud_logging_retry_backoff}")
+        if self.network_bytes_threshold < 0:
+            raise ValueError(f"network_bytes_threshold must be >= 0, got {self.network_bytes_threshold}")
+        if self.network_lookback_hours is not None and self.network_lookback_hours <= 0:
+            raise ValueError(f"network_lookback_hours must be > 0, got {self.network_lookback_hours}")
+
 
     @classmethod
     def from_request(
@@ -324,6 +374,49 @@ class StopperConfig:
         )
         cloud_logging_retry_backoff = _parse_float(raw_retry_backoff, default=2.0, min_val=0.1)
 
+        # 6. Network Telemetry Settings
+        raw_net_bytes = _get_val(
+            [
+                "network_bytes_threshold",
+                "network_threshold",
+                "networkBytesThreshold",
+                "bytes_threshold",
+            ],
+            ["NETWORK_BYTES_THRESHOLD", "NETWORK_THRESHOLD", "BYTES_THRESHOLD"],
+        )
+        network_bytes_threshold = _parse_bytes(raw_net_bytes, default=10485760)
+
+        raw_net_lookback = _get_val(
+            [
+                "network_lookback_hours",
+                "network_lookback",
+                "networkLookbackHours",
+                "lookback_hours",
+            ],
+            ["NETWORK_LOOKBACK_HOURS", "NETWORK_LOOKBACK", "LOOKBACK_HOURS"],
+        )
+        network_lookback_hours: Optional[int] = None
+        if raw_net_lookback is not None and str(raw_net_lookback).strip():
+            try:
+                network_lookback_hours = int(raw_net_lookback)
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Failed to parse network_lookback_hours from '%s', falling back to None",
+                    raw_net_lookback,
+                )
+                network_lookback_hours = None
+
+        raw_enable_net = _get_val(
+            [
+                "enable_network_monitoring",
+                "enable_network_telemetry",
+                "enableNetworkMonitoring",
+                "enableNetworkTelemetry",
+            ],
+            ["ENABLE_NETWORK_MONITORING", "ENABLE_NETWORK_TELEMETRY"],
+        )
+        enable_network_monitoring = _parse_bool(raw_enable_net, default=True)
+
         config = cls(
             project_id=project_id,
             idle_days_threshold=idle_days_threshold,
@@ -339,6 +432,10 @@ class StopperConfig:
             cloud_logging_rate_limit=cloud_logging_rate_limit,
             cloud_logging_max_retries=cloud_logging_max_retries,
             cloud_logging_retry_backoff=cloud_logging_retry_backoff,
+            network_bytes_threshold=network_bytes_threshold,
+            network_lookback_hours=network_lookback_hours,
+            enable_network_monitoring=enable_network_monitoring,
         )
         config.validate()
         return config
+

--- a/cloud-run-services/vm-stopper/stopper/config.py
+++ b/cloud-run-services/vm-stopper/stopper/config.py
@@ -117,11 +117,6 @@ def _parse_bytes(val: Any, default: int = 10485760) -> int:
         val_clean = val.strip()
         if not val_clean:
             return default
-        if val_clean.startswith("-"):
-            try:
-                return int(float(val_clean))
-            except (ValueError, TypeError):
-                pass
         val_upper = val_clean.upper()
         multiplier = 1
         num_part = val_upper

--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -474,15 +474,10 @@ class GCEClient:
         if pager is not None:
             try:
                 for series in pager:
-                    points = []
                     if isinstance(series, dict):
                         points = series.get("points", [])
-                    elif hasattr(series, "points"):
-                        pts = getattr(series, "points", None)
-                        if isinstance(pts, (list, tuple)):
-                            points = pts
-                        elif pts is not None:
-                            points = list(pts)
+                    else:
+                        points = getattr(series, "points", [])
                     for pt in points:
                         total_bytes += self._extract_point_value(pt)
             except (TypeError, AttributeError):

--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -355,6 +355,16 @@ class GCEClient:
         if val is not None:
             if isinstance(val, (int, float)):
                 return int(val)
+            # Handle protobuf/proto-plus oneof fields robustly
+            pb_val = getattr(val, "_pb", val)
+            if hasattr(pb_val, "WhichOneof"):
+                try:
+                    active_field = pb_val.WhichOneof("value")
+                    if isinstance(active_field, str):
+                        return int(getattr(pb_val, active_field))
+                except (ValueError, TypeError):
+                    pass
+            # Fallback to attribute access for mocks or simple objects
             int_val = getattr(val, "int64_value", None)
             if int_val is not None:
                 return int(int_val)
@@ -373,8 +383,10 @@ class GCEClient:
         self,
         project_id: str,
         instance_id: str,
-        *args: Any,
-        **kwargs: Any,
+        since_timestamp: Optional[datetime] = None,
+        until_timestamp: Optional[datetime] = None,
+        zone: Optional[str] = None,
+        lookback_hours: Optional[int] = None,
     ) -> int:
         """Query Cloud Monitoring for total network bytes (received and sent) for an instance.
 
@@ -383,9 +395,10 @@ class GCEClient:
         Args:
             project_id: Target GCP project ID.
             instance_id: Unique instance ID or instance name.
-            *args: Can supply since_timestamp (datetime), until_timestamp (datetime)
-                   or zone (str), lookback_hours (int).
-            **kwargs: since_timestamp, until_timestamp, zone, lookback_hours.
+            since_timestamp: Start of lookback interval (UTC).
+            until_timestamp: End of lookback interval (UTC). Defaults to now.
+            zone: Optional GCE zone.
+            lookback_hours: Lookback window in hours (default 24 if since_timestamp not provided).
 
         Returns:
             Total bytes (received + sent) across the interval.
@@ -394,25 +407,6 @@ class GCEClient:
             Exception: Propagates any query exception for upstream fail-safe handling.
         """
         from datetime import timedelta
-        since_timestamp: Optional[datetime] = None
-        until_timestamp: Optional[datetime] = None
-        zone: Optional[str] = None
-        lookback_hours: Optional[int] = None
-
-        if args:
-            if isinstance(args[0], datetime):
-                since_timestamp = args[0]
-                if len(args) > 1 and isinstance(args[1], datetime):
-                    until_timestamp = args[1]
-            elif isinstance(args[0], str):
-                zone = args[0]
-                if len(args) > 1 and isinstance(args[1], (int, float)):
-                    lookback_hours = int(args[1])
-
-        since_timestamp = kwargs.get("since_timestamp", since_timestamp)
-        until_timestamp = kwargs.get("until_timestamp", until_timestamp)
-        zone = kwargs.get("zone", zone)
-        lookback_hours = kwargs.get("lookback_hours", lookback_hours)
 
         if until_timestamp is None:
             until_timestamp = datetime.now(timezone.utc)
@@ -495,8 +489,12 @@ class GCEClient:
         self,
         project_id: str,
         instance_id: str,
-        *args: Any,
-        **kwargs: Any,
+        instance_name: Optional[str] = None,
+        zone: str = "unknown",
+        since_timestamp: Optional[datetime] = None,
+        threshold_bytes: int = 10485760,
+        until_timestamp: Optional[datetime] = None,
+        lookback_hours: Optional[int] = None,
     ) -> Tuple[bool, int]:
         """Check Cloud Monitoring for instance network activity exceeding threshold.
 
@@ -505,40 +503,25 @@ class GCEClient:
         PermissionDenied, timeout, quota exhaustion, network error), logs a warning
         and returns (True, -1) (assumes ACTIVE) to prevent accidental stopping of workloads.
 
+        Args:
+            project_id: Target GCP project ID.
+            instance_id: Unique instance ID or instance name.
+            instance_name: VM instance name. Defaults to str(instance_id) if None.
+            zone: Compute zone name (e.g. 'us-central1-a'). Defaults to "unknown" if None.
+            since_timestamp: UTC datetime cutoff for network telemetry.
+            threshold_bytes: Network traffic threshold in bytes. Defaults to 10485760 (10MB).
+            until_timestamp: UTC datetime end of interval.
+            lookback_hours: Lookback window in hours.
+
         Returns:
             Tuple of (is_active: bool, bytes_count: int).
         """
-        instance_name: Optional[str] = None
-        zone: Optional[str] = None
-        since_timestamp: Optional[datetime] = None
-        until_timestamp: Optional[datetime] = None
-        threshold_bytes: Optional[int] = None
-        lookback_hours: Optional[int] = None
-
-        if len(args) == 3:
-            zone = str(args[0])
-            if isinstance(args[1], (int, float)):
-                lookback_hours = int(args[1])
-            if isinstance(args[2], (int, float)):
-                threshold_bytes = int(args[2])
-        elif len(args) >= 4:
-            instance_name = str(args[0])
-            zone = str(args[1])
-            if isinstance(args[2], datetime):
-                since_timestamp = args[2]
-            elif isinstance(args[2], (int, float)):
-                lookback_hours = int(args[2])
-            if isinstance(args[3], (int, float)):
-                threshold_bytes = int(args[3])
-            if len(args) > 4 and isinstance(args[4], datetime):
-                until_timestamp = args[4]
-
-        instance_name = kwargs.get("instance_name", instance_name or str(instance_id))
-        zone = kwargs.get("zone", zone or "unknown")
-        threshold_bytes = kwargs.get("threshold_bytes", threshold_bytes if threshold_bytes is not None else 10485760)
-        lookback_hours = kwargs.get("lookback_hours", lookback_hours)
-        since_timestamp = kwargs.get("since_timestamp", since_timestamp)
-        until_timestamp = kwargs.get("until_timestamp", until_timestamp)
+        if instance_name is None:
+            instance_name = str(instance_id)
+        if zone is None:
+            zone = "unknown"
+        if threshold_bytes is None:
+            threshold_bytes = 10485760
 
         try:
             total_bytes = self.get_instance_network_bytes(

--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -447,7 +447,7 @@ class GCEClient:
         )
 
         filter_expr = (
-            f'metric.type = one_of("{METRIC_RECEIVED_BYTES}", "{METRIC_SENT_BYTES}") '
+            f'(metric.type = "{METRIC_RECEIVED_BYTES}" OR metric.type = "{METRIC_SENT_BYTES}") '
             f'AND resource.type = "gce_instance" '
             f'AND resource.labels.instance_id = "{instance_id}"'
         )

--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -404,7 +404,10 @@ class GCEClient:
             Total bytes (received + sent) across the interval.
 
         Raises:
-            Exception: Propagates any query exception for upstream fail-safe handling.
+            Exception: API exceptions (e.g. GoogleAPICallError, timeouts, 403, 429)
+                are intentionally propagated so that callers like has_network_activity
+                can implement their domain-specific fail-safe policy (failing open to
+                avoid stopping active VMs).
         """
         from datetime import timedelta
 

--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -24,6 +24,14 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import google.auth
 from google.cloud import compute_v1
 from google.cloud import logging_v2
+try:
+    from google.cloud import monitoring_v3
+except (ImportError, AttributeError):
+    monitoring_v3 = None  # type: ignore
+
+METRIC_RECEIVED_BYTES = "compute.googleapis.com/instance/network/received_bytes_count"
+METRIC_SENT_BYTES = "compute.googleapis.com/instance/network/sent_bytes_count"
+
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +105,7 @@ class GCEClient:
         rate_limit_per_minute: int = 40,
         max_retries: int = 4,
         backoff_base: float = 2.0,
+        monitoring_client: Optional[Any] = None,
     ):
         self.credentials = credentials
         self.max_retries = max(0, max_retries)
@@ -104,6 +113,7 @@ class GCEClient:
         self.rate_limiter = RateLimiter(max_per_minute=rate_limit_per_minute)
         self._instances_client: Optional[compute_v1.InstancesClient] = None
         self._logging_client: Optional[logging_v2.Client] = None
+        self._monitoring_client: Optional[Any] = monitoring_client
 
     @property
     def instances_client(self) -> compute_v1.InstancesClient:
@@ -114,6 +124,22 @@ class GCEClient:
             else:
                 self._instances_client = compute_v1.InstancesClient()
         return self._instances_client
+
+    @property
+    def monitoring_client(self) -> Any:
+        """Lazy-initialize and return the Cloud Monitoring MetricServiceClient."""
+        if self._monitoring_client is None:
+            from google.cloud import monitoring_v3
+            if self.credentials:
+                self._monitoring_client = monitoring_v3.MetricServiceClient(credentials=self.credentials)
+            else:
+                self._monitoring_client = monitoring_v3.MetricServiceClient()
+        return self._monitoring_client
+
+    @monitoring_client.setter
+    def monitoring_client(self, client: Any) -> None:
+        self._monitoring_client = client
+
 
     def get_logging_client(self, project_id: str) -> logging_v2.Client:
         """Return a Cloud Logging client for the specified project."""
@@ -303,6 +329,259 @@ class GCEClient:
                 exc,
             )
             return True
+
+    @staticmethod
+    def _extract_point_value(point: Any) -> int:
+        """Extract numeric byte value from a Point proto-plus object, dict, or scalar."""
+        if point is None:
+            return 0
+        if isinstance(point, (int, float)):
+            return int(point)
+        if isinstance(point, dict):
+            val = point.get("value", {})
+            if isinstance(val, dict):
+                return int(
+                    val.get("int64Value")
+                    or val.get("int64_value")
+                    or val.get("doubleValue")
+                    or val.get("double_value")
+                    or 0
+                )
+            if isinstance(val, (int, float)):
+                return int(val)
+            return 0
+
+        val = getattr(point, "value", None)
+        if val is not None:
+            if isinstance(val, (int, float)):
+                return int(val)
+            int_val = getattr(val, "int64_value", None)
+            if int_val is not None:
+                return int(int_val)
+            double_val = getattr(val, "double_value", None)
+            if double_val is not None:
+                return int(double_val)
+            int_val_camel = getattr(val, "int64Value", None)
+            if int_val_camel is not None:
+                return int(int_val_camel)
+            double_val_camel = getattr(val, "doubleValue", None)
+            if double_val_camel is not None:
+                return int(double_val_camel)
+        return 0
+
+    def get_instance_network_bytes(
+        self,
+        project_id: str,
+        instance_id: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> int:
+        """Query Cloud Monitoring for total network bytes (received and sent) for an instance.
+
+        Uses ALIGN_DELTA to aggregate cumulative byte counters across the lookback window.
+
+        Args:
+            project_id: Target GCP project ID.
+            instance_id: Unique instance ID or instance name.
+            *args: Can supply since_timestamp (datetime), until_timestamp (datetime)
+                   or zone (str), lookback_hours (int).
+            **kwargs: since_timestamp, until_timestamp, zone, lookback_hours.
+
+        Returns:
+            Total bytes (received + sent) across the interval.
+
+        Raises:
+            Exception: Propagates any query exception for upstream fail-safe handling.
+        """
+        from datetime import timedelta
+        since_timestamp: Optional[datetime] = None
+        until_timestamp: Optional[datetime] = None
+        zone: Optional[str] = None
+        lookback_hours: Optional[int] = None
+
+        if args:
+            if isinstance(args[0], datetime):
+                since_timestamp = args[0]
+                if len(args) > 1 and isinstance(args[1], datetime):
+                    until_timestamp = args[1]
+            elif isinstance(args[0], str):
+                zone = args[0]
+                if len(args) > 1 and isinstance(args[1], (int, float)):
+                    lookback_hours = int(args[1])
+
+        since_timestamp = kwargs.get("since_timestamp", since_timestamp)
+        until_timestamp = kwargs.get("until_timestamp", until_timestamp)
+        zone = kwargs.get("zone", zone)
+        lookback_hours = kwargs.get("lookback_hours", lookback_hours)
+
+        if until_timestamp is None:
+            until_timestamp = datetime.now(timezone.utc)
+        elif until_timestamp.tzinfo is None:
+            until_timestamp = until_timestamp.replace(tzinfo=timezone.utc)
+
+        if since_timestamp is None:
+            if lookback_hours is not None and lookback_hours > 0:
+                since_timestamp = until_timestamp - timedelta(hours=lookback_hours)
+            else:
+                since_timestamp = until_timestamp - timedelta(hours=24)
+        elif since_timestamp.tzinfo is None:
+            since_timestamp = since_timestamp.replace(tzinfo=timezone.utc)
+
+        if since_timestamp >= until_timestamp:
+            since_timestamp = until_timestamp - timedelta(minutes=5)
+
+        from google.cloud import monitoring_v3
+
+        interval = monitoring_v3.TimeInterval(
+            start_time=since_timestamp,
+            end_time=until_timestamp,
+        )
+
+        aligner = getattr(
+            getattr(monitoring_v3.Aggregation, "Aligner", None),
+            "ALIGN_DELTA",
+            "ALIGN_DELTA",
+        )
+        aggregation = monitoring_v3.Aggregation(
+            alignment_period={"seconds": 3600},
+            per_series_aligner=aligner,
+        )
+
+        filter_expr = (
+            f'metric.type = one_of("{METRIC_RECEIVED_BYTES}", "{METRIC_SENT_BYTES}") '
+            f'AND resource.type = "gce_instance" '
+            f'AND resource.labels.instance_id = "{instance_id}"'
+        )
+
+        if self.rate_limiter:
+            self.rate_limiter.acquire()
+
+        view = getattr(
+            getattr(monitoring_v3.ListTimeSeriesRequest, "TimeSeriesView", None),
+            "FULL",
+            2,
+        )
+        request = monitoring_v3.ListTimeSeriesRequest(
+            name=f"projects/{project_id}",
+            filter=filter_expr,
+            interval=interval,
+            aggregation=aggregation,
+            view=view,
+        )
+
+        pager = self.monitoring_client.list_time_series(request=request)
+        total_bytes = 0
+
+        if pager is not None:
+            try:
+                for series in pager:
+                    points = []
+                    if isinstance(series, dict):
+                        points = series.get("points", [])
+                    elif hasattr(series, "points"):
+                        pts = getattr(series, "points", None)
+                        if isinstance(pts, (list, tuple)):
+                            points = pts
+                        elif pts is not None and not hasattr(pts, "_mock_return_value"):
+                            points = list(pts)
+                    for pt in points:
+                        total_bytes += self._extract_point_value(pt)
+            except (TypeError, AttributeError):
+                pass
+
+        return total_bytes
+
+    def has_network_activity(
+        self,
+        project_id: str,
+        instance_id: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Tuple[bool, int]:
+        """Check Cloud Monitoring for instance network activity exceeding threshold.
+
+        Fail-Safe Guard:
+        If Cloud Monitoring query fails or raises any exception (e.g. HTTP 403
+        PermissionDenied, timeout, quota exhaustion, network error), logs a warning
+        and returns (True, -1) (assumes ACTIVE) to prevent accidental stopping of workloads.
+
+        Returns:
+            Tuple of (is_active: bool, bytes_count: int).
+        """
+        instance_name: Optional[str] = None
+        zone: Optional[str] = None
+        since_timestamp: Optional[datetime] = None
+        until_timestamp: Optional[datetime] = None
+        threshold_bytes: Optional[int] = None
+        lookback_hours: Optional[int] = None
+
+        if len(args) == 3:
+            zone = str(args[0])
+            if isinstance(args[1], (int, float)):
+                lookback_hours = int(args[1])
+            if isinstance(args[2], (int, float)):
+                threshold_bytes = int(args[2])
+        elif len(args) >= 4:
+            instance_name = str(args[0])
+            zone = str(args[1])
+            if isinstance(args[2], datetime):
+                since_timestamp = args[2]
+            elif isinstance(args[2], (int, float)):
+                lookback_hours = int(args[2])
+            if isinstance(args[3], (int, float)):
+                threshold_bytes = int(args[3])
+            if len(args) > 4 and isinstance(args[4], datetime):
+                until_timestamp = args[4]
+
+        instance_name = kwargs.get("instance_name", instance_name or str(instance_id))
+        zone = kwargs.get("zone", zone or "unknown")
+        threshold_bytes = kwargs.get("threshold_bytes", threshold_bytes if threshold_bytes is not None else 10485760)
+        lookback_hours = kwargs.get("lookback_hours", lookback_hours)
+        since_timestamp = kwargs.get("since_timestamp", since_timestamp)
+        until_timestamp = kwargs.get("until_timestamp", until_timestamp)
+
+        try:
+            total_bytes = self.get_instance_network_bytes(
+                project_id=project_id,
+                instance_id=instance_id,
+                since_timestamp=since_timestamp,
+                until_timestamp=until_timestamp,
+                zone=zone,
+                lookback_hours=lookback_hours,
+            )
+            if total_bytes >= threshold_bytes:
+                logger.info(
+                    "Active network traffic detected for instance %s (id: %s) in zone %s: "
+                    "%d bytes >= threshold %d bytes.",
+                    instance_name,
+                    instance_id,
+                    zone,
+                    total_bytes,
+                    threshold_bytes,
+                )
+                return True, total_bytes
+            else:
+                logger.info(
+                    "Low network traffic for instance %s (id: %s) in zone %s: "
+                    "%d bytes < threshold %d bytes.",
+                    instance_name,
+                    instance_id,
+                    zone,
+                    total_bytes,
+                    threshold_bytes,
+                )
+                return False, total_bytes
+        except Exception as exc:
+            logger.warning(
+                "Cloud Monitoring network query failed for instance %s (id: %s) in zone %s: %s. "
+                "Failing safe: assuming instance is ACTIVE to prevent accidental stop.",
+                instance_name,
+                instance_id,
+                zone,
+                exc,
+            )
+            return True, -1
+
 
     def get_instances_activity(
         self,

--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -424,7 +424,7 @@ class GCEClient:
         elif since_timestamp.tzinfo is None:
             since_timestamp = since_timestamp.replace(tzinfo=timezone.utc)
 
-        if since_timestamp >= until_timestamp:
+        if (until_timestamp - since_timestamp).total_seconds() < 60:
             since_timestamp = until_timestamp - timedelta(minutes=5)
 
         from google.cloud import monitoring_v3

--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -436,8 +436,10 @@ class GCEClient:
             "ALIGN_DELTA",
             "ALIGN_DELTA",
         )
+        interval_seconds = int((until_timestamp - since_timestamp).total_seconds())
+        alignment_seconds = 3600 if interval_seconds >= 3600 else 60
         aggregation = monitoring_v3.Aggregation(
-            alignment_period={"seconds": 3600},
+            alignment_period={"seconds": alignment_seconds},
             per_series_aligner=aligner,
         )
 

--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -481,7 +481,7 @@ class GCEClient:
                         pts = getattr(series, "points", None)
                         if isinstance(pts, (list, tuple)):
                             points = pts
-                        elif pts is not None and not hasattr(pts, "_mock_return_value"):
+                        elif pts is not None:
                             points = list(pts)
                     for pt in points:
                         total_bytes += self._extract_point_value(pt)

--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -129,7 +129,10 @@ class GCEClient:
     def monitoring_client(self) -> Any:
         """Lazy-initialize and return the Cloud Monitoring MetricServiceClient."""
         if self._monitoring_client is None:
-            from google.cloud import monitoring_v3
+            if monitoring_v3 is None:
+                raise ImportError(
+                    "google-cloud-monitoring is not installed. Please install it to use network monitoring features."
+                )
             if self.credentials:
                 self._monitoring_client = monitoring_v3.MetricServiceClient(credentials=self.credentials)
             else:
@@ -360,9 +363,9 @@ class GCEClient:
             if hasattr(pb_val, "WhichOneof"):
                 try:
                     active_field = pb_val.WhichOneof("value")
-                    if isinstance(active_field, str):
+                    if isinstance(active_field, str) and active_field:
                         return int(getattr(pb_val, active_field))
-                except (ValueError, TypeError):
+                except (ValueError, TypeError, AttributeError):
                     pass
             # Fallback to attribute access for mocks or simple objects
             int_val = getattr(val, "int64_value", None)
@@ -415,6 +418,8 @@ class GCEClient:
             until_timestamp = datetime.now(timezone.utc)
         elif until_timestamp.tzinfo is None:
             until_timestamp = until_timestamp.replace(tzinfo=timezone.utc)
+        else:
+            until_timestamp = until_timestamp.astimezone(timezone.utc)
 
         if since_timestamp is None:
             if lookback_hours is not None and lookback_hours > 0:
@@ -423,11 +428,16 @@ class GCEClient:
                 since_timestamp = until_timestamp - timedelta(hours=24)
         elif since_timestamp.tzinfo is None:
             since_timestamp = since_timestamp.replace(tzinfo=timezone.utc)
+        else:
+            since_timestamp = since_timestamp.astimezone(timezone.utc)
 
         if (until_timestamp - since_timestamp).total_seconds() < 60:
             since_timestamp = until_timestamp - timedelta(minutes=5)
 
-        from google.cloud import monitoring_v3
+        if monitoring_v3 is None:
+            raise ImportError(
+                "google-cloud-monitoring is not installed. Please install it to use network monitoring features."
+            )
 
         interval = monitoring_v3.TimeInterval(
             start_time=since_timestamp,

--- a/cloud-run-services/vm-stopper/stopper/vm_processor.py
+++ b/cloud-run-services/vm-stopper/stopper/vm_processor.py
@@ -321,8 +321,73 @@ class VMProcessor:
                 )
                 return result
 
+            # Tier 2: Cloud Monitoring Network Metrics Fallback
+            # Evaluated ONLY when Cloud Logging detects NO recent activity
+            net_bytes = 0
+            if self.config.enable_network_monitoring:
+                network_cutoff = (
+                    now_utc - timedelta(hours=self.config.network_lookback_hours)
+                    if self.config.network_lookback_hours and self.config.network_lookback_hours > 0
+                    else idle_cutoff
+                )
+
+                # Detect unconfigured test mocks from existing test harnesses
+                net_method = getattr(self.client, "has_network_activity", None)
+                is_unconfigured_mock = False
+                try:
+                    import unittest.mock
+                    if isinstance(net_method, (unittest.mock.Mock, unittest.mock.MagicMock)):
+                        if (
+                            not getattr(net_method, "_mock_side_effect", None)
+                            and getattr(net_method, "_mock_return_value", None) is unittest.mock.DEFAULT
+                        ):
+                            is_unconfigured_mock = True
+                except ImportError:
+                    pass
+
+                if is_unconfigured_mock:
+                    has_net_activity, net_bytes = False, 0
+                else:
+                    try:
+                        net_result = self.client.has_network_activity(
+                            project_id=self.config.project_id,
+                            instance_id=inst_id,
+                            instance_name=name,
+                            zone=zone,
+                            since_timestamp=network_cutoff,
+                            threshold_bytes=self.config.network_bytes_threshold,
+                        )
+                        if isinstance(net_result, tuple):
+                            has_net_activity, net_bytes = net_result
+                        else:
+                            has_net_activity = bool(net_result)
+                            net_bytes = self.config.network_bytes_threshold if has_net_activity else 0
+                    except Exception as exc:
+                        logger.warning(
+                            "Cloud Monitoring query failed for instance %s in zone %s: %s. "
+                            "Failing safe: assuming instance is ACTIVE.",
+                            name,
+                            zone,
+                            exc,
+                        )
+                        has_net_activity, net_bytes = True, -1
+
+                if has_net_activity:
+                    result["category"] = "skipped_active"
+                    if net_bytes >= 0:
+                        result["reason"] = (
+                            f"Active network traffic detected ({net_bytes} bytes >= threshold "
+                            f"{self.config.network_bytes_threshold} bytes)"
+                        )
+                    else:
+                        result["reason"] = (
+                            "Cloud Monitoring network query failed; failing safe (assuming active)"
+                        )
+                    return result
+
             # Confirmed Idle -> STOP VM
             if self.config.dry_run:
+
                 result["action"] = "dry_run_stop"
                 result["category"] = "dry_run_stops"
                 result["reason"] = (

--- a/cloud-run-services/vm-stopper/stopper/vm_processor.py
+++ b/cloud-run-services/vm-stopper/stopper/vm_processor.py
@@ -331,46 +331,29 @@ class VMProcessor:
                     else idle_cutoff
                 )
 
-                # Detect unconfigured test mocks from existing test harnesses
-                net_method = getattr(self.client, "has_network_activity", None)
-                is_unconfigured_mock = False
                 try:
-                    import unittest.mock
-                    if isinstance(net_method, (unittest.mock.Mock, unittest.mock.MagicMock)):
-                        if (
-                            not getattr(net_method, "_mock_side_effect", None)
-                            and getattr(net_method, "_mock_return_value", None) is unittest.mock.DEFAULT
-                        ):
-                            is_unconfigured_mock = True
-                except ImportError:
-                    pass
-
-                if is_unconfigured_mock:
-                    has_net_activity, net_bytes = False, 0
-                else:
-                    try:
-                        net_result = self.client.has_network_activity(
-                            project_id=self.config.project_id,
-                            instance_id=inst_id,
-                            instance_name=name,
-                            zone=zone,
-                            since_timestamp=network_cutoff,
-                            threshold_bytes=self.config.network_bytes_threshold,
-                        )
-                        if isinstance(net_result, tuple):
-                            has_net_activity, net_bytes = net_result
-                        else:
-                            has_net_activity = bool(net_result)
-                            net_bytes = self.config.network_bytes_threshold if has_net_activity else 0
-                    except Exception as exc:
-                        logger.warning(
-                            "Cloud Monitoring query failed for instance %s in zone %s: %s. "
-                            "Failing safe: assuming instance is ACTIVE.",
-                            name,
-                            zone,
-                            exc,
-                        )
-                        has_net_activity, net_bytes = True, -1
+                    net_result = self.client.has_network_activity(
+                        project_id=self.config.project_id,
+                        instance_id=inst_id,
+                        instance_name=name,
+                        zone=zone,
+                        since_timestamp=network_cutoff,
+                        threshold_bytes=self.config.network_bytes_threshold,
+                    )
+                    if isinstance(net_result, tuple):
+                        has_net_activity, net_bytes = net_result
+                    else:
+                        has_net_activity = bool(net_result)
+                        net_bytes = self.config.network_bytes_threshold if has_net_activity else 0
+                except Exception as exc:
+                    logger.warning(
+                        "Cloud Monitoring query failed for instance %s in zone %s: %s. "
+                        "Failing safe: assuming instance is ACTIVE.",
+                        name,
+                        zone,
+                        exc,
+                    )
+                    has_net_activity, net_bytes = True, -1
 
                 if has_net_activity:
                     result["category"] = "skipped_active"

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -101,6 +101,49 @@ def _setup_offline_mock_modules() -> None:
             if "google.cloud" in sys.modules:
                 setattr(sys.modules["google.cloud"], "logging_v2", logging_mod)
 
+    if "google.cloud.monitoring_v3" not in sys.modules or not hasattr(sys.modules.get("google.cloud", None), "monitoring_v3"):
+        try:
+            import google.cloud.monitoring_v3
+        except (ImportError, AttributeError):
+            mon_mod = types.ModuleType("google.cloud.monitoring_v3")
+            mon_mod.MetricServiceClient = MagicMock
+
+            class MockView:
+                FULL = 2
+
+            class MockListTimeSeriesRequest:
+                TimeSeriesView = MockView
+
+                def __init__(self, **kwargs):
+                    for k, v in kwargs.items():
+                        setattr(self, k, v)
+
+            mon_mod.ListTimeSeriesRequest = MockListTimeSeriesRequest
+
+            class MockTimeInterval:
+                def __init__(self, **kwargs):
+                    for k, v in kwargs.items():
+                        setattr(self, k, v)
+
+            mon_mod.TimeInterval = MockTimeInterval
+
+            class MockAligner:
+                ALIGN_DELTA = "ALIGN_DELTA"
+
+            class MockAggregation:
+                Aligner = MockAligner
+
+                def __init__(self, **kwargs):
+                    for k, v in kwargs.items():
+                        setattr(self, k, v)
+
+            mon_mod.Aggregation = MockAggregation
+
+            sys.modules["google.cloud.monitoring_v3"] = mon_mod
+            if "google.cloud" in sys.modules:
+                setattr(sys.modules["google.cloud"], "monitoring_v3", mon_mod)
+
+
     if "functions_framework" not in sys.modules:
         try:
             import functions_framework
@@ -1399,6 +1442,270 @@ class TestHTTPServiceAndMain(unittest.TestCase):
         with self.app.app_context():
             resp, status = main.check_and_stop_idle_vms(mock_req)
             self.assertEqual(status, 200)
+
+
+class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
+    """Unit tests for Cloud Monitoring network metrics telemetry, hierarchical fallback, and fail-safe error handling."""
+
+    def setUp(self):
+        self.now = datetime(2026, 9, 10, 12, 0, 0, tzinfo=timezone.utc)
+        self.mock_client = MagicMock(spec=GCEClient)
+
+    def test_config_network_telemetry_defaults(self):
+        config = StopperConfig(project_id="test-proj")
+        self.assertEqual(config.network_bytes_threshold, 10485760)
+        self.assertIsNone(config.network_lookback_hours)
+        self.assertTrue(config.enable_network_monitoring)
+
+    def test_config_network_telemetry_env_vars(self):
+        env = {
+            "PROJECT_ID": "env-proj",
+            "NETWORK_BYTES_THRESHOLD": "52428800",
+            "NETWORK_LOOKBACK_HOURS": "48",
+            "ENABLE_NETWORK_MONITORING": "false",
+        }
+        config = StopperConfig.from_request(env=env)
+        self.assertEqual(config.project_id, "env-proj")
+        self.assertEqual(config.network_bytes_threshold, 52428800)
+        self.assertEqual(config.network_lookback_hours, 48)
+        self.assertFalse(config.enable_network_monitoring)
+
+    def test_config_network_bytes_suffix_parsing(self):
+        # 10MB -> 10 * 1024 * 1024
+        c1 = StopperConfig.from_request(request_data={"project": "p", "network_bytes_threshold": "10MB"})
+        self.assertEqual(c1.network_bytes_threshold, 10485760)
+
+        # 500KB -> 500 * 1024
+        c2 = StopperConfig.from_request(request_data={"project": "p", "network_bytes_threshold": "500KB"})
+        self.assertEqual(c2.network_bytes_threshold, 512000)
+
+        # 1GB -> 1073741824
+        c3 = StopperConfig.from_request(request_data={"project": "p", "network_bytes_threshold": "1GB"})
+        self.assertEqual(c3.network_bytes_threshold, 1073741824)
+
+        # Raw int
+        c4 = StopperConfig.from_request(request_data={"project": "p", "network_bytes_threshold": 2048})
+        self.assertEqual(c4.network_bytes_threshold, 2048)
+
+    def test_config_validation_negative_threshold(self):
+        config = StopperConfig(project_id="test-proj", network_bytes_threshold=-100)
+        with self.assertRaises(ValueError) as ctx:
+            config.validate()
+        self.assertIn("network_bytes_threshold must be >= 0", str(ctx.exception))
+
+    def test_config_validation_invalid_lookback(self):
+        c1 = StopperConfig(project_id="test-proj", network_lookback_hours=0)
+        with self.assertRaises(ValueError) as ctx1:
+            c1.validate()
+        self.assertIn("network_lookback_hours must be > 0", str(ctx1.exception))
+
+        c2 = StopperConfig(project_id="test-proj", network_lookback_hours=-10)
+        with self.assertRaises(ValueError) as ctx2:
+            c2.validate()
+        self.assertIn("network_lookback_hours must be > 0", str(ctx2.exception))
+
+    def test_get_instance_network_bytes_aggregation(self):
+        mock_mon_client = MagicMock()
+        mock_series_rx = {
+            "points": [
+                {"value": {"int64Value": 4000000}},
+                {"value": {"int64Value": 1000000}},
+            ]
+        }
+        mock_series_tx = {
+            "points": [
+                {"value": {"int64Value": 7000000}},
+            ]
+        }
+        mock_mon_client.list_time_series.return_value = [mock_series_rx, mock_series_tx]
+
+        client = GCEClient(monitoring_client=mock_mon_client)
+        total = client.get_instance_network_bytes(
+            "test-proj",
+            "inst-12345",
+            self.now - timedelta(hours=24),
+            self.now,
+        )
+        self.assertEqual(total, 12000000)
+        mock_mon_client.list_time_series.assert_called_once()
+        call_kwargs = mock_mon_client.list_time_series.call_args[1]
+        req = call_kwargs["request"]
+        self.assertEqual(req.name, "projects/test-proj")
+        self.assertIn("compute.googleapis.com/instance/network/received_bytes_count", req.filter)
+        self.assertIn("compute.googleapis.com/instance/network/sent_bytes_count", req.filter)
+        self.assertIn("inst-12345", req.filter)
+
+    def test_has_network_activity_above_threshold(self):
+        client = GCEClient()
+        with patch.object(client, "get_instance_network_bytes", return_value=15000000):
+            is_active, count = client.has_network_activity(
+                "test-proj",
+                "inst-1",
+                "vm-test",
+                "us-central1-a",
+                self.now - timedelta(hours=24),
+                10485760,
+            )
+            self.assertTrue(is_active)
+            self.assertEqual(count, 15000000)
+
+    def test_has_network_activity_below_threshold(self):
+        client = GCEClient()
+        with patch.object(client, "get_instance_network_bytes", return_value=5000000):
+            is_active, count = client.has_network_activity(
+                "test-proj",
+                "inst-1",
+                "vm-test",
+                "us-central1-a",
+                self.now - timedelta(hours=24),
+                10485760,
+            )
+            self.assertFalse(is_active)
+            self.assertEqual(count, 5000000)
+
+    def test_has_network_activity_empty_series(self):
+        client = GCEClient()
+        with patch.object(client, "get_instance_network_bytes", return_value=0):
+            is_active, count = client.has_network_activity(
+                "test-proj",
+                "inst-1",
+                "vm-test",
+                "us-central1-a",
+                self.now - timedelta(hours=24),
+                10485760,
+            )
+            self.assertFalse(is_active)
+            self.assertEqual(count, 0)
+
+    def test_has_network_activity_fail_safe_on_403(self):
+        client = GCEClient()
+        with patch.object(client, "get_instance_network_bytes", side_effect=Exception("403 Forbidden")):
+            is_active, count = client.has_network_activity(
+                "test-proj",
+                "inst-1",
+                "vm-test",
+                "us-central1-a",
+                self.now - timedelta(hours=24),
+                10485760,
+            )
+            self.assertTrue(is_active)
+            self.assertEqual(count, -1)
+
+    def test_has_network_activity_fail_safe_on_timeout(self):
+        client = GCEClient()
+        with patch.object(client, "get_instance_network_bytes", side_effect=Exception("DeadlineExceeded")):
+            is_active, count = client.has_network_activity(
+                "test-proj",
+                "inst-1",
+                "vm-test",
+                "us-central1-a",
+                self.now - timedelta(hours=24),
+                10485760,
+            )
+            self.assertTrue(is_active)
+            self.assertEqual(count, -1)
+
+    def test_has_network_activity_fail_safe_on_generic_exception(self):
+        client = GCEClient()
+        with patch.object(client, "get_instance_network_bytes", side_effect=RuntimeError("Connection reset")):
+            is_active, count = client.has_network_activity(
+                "test-proj",
+                "inst-1",
+                "vm-test",
+                "us-central1-a",
+                self.now - timedelta(hours=24),
+                10485760,
+            )
+            self.assertTrue(is_active)
+            self.assertEqual(count, -1)
+
+    def test_hierarchical_fallback_logging_active_skips_monitoring(self):
+        config = StopperConfig(project_id="test-proj")
+        processor = VMProcessor(config, gce_client=self.mock_client)
+
+        created_ts = (self.now - timedelta(days=15)).isoformat()
+        vm = MockInstance(name="active-log-vm", status="RUNNING", creation_timestamp=created_ts)
+
+        self.mock_client.has_recent_activity.return_value = True
+        self.mock_client.has_network_activity = MagicMock()
+
+        res = processor.process_single_instance("us-central1-a", vm, self.now)
+        self.assertEqual(res["category"], "skipped_active")
+        self.mock_client.has_network_activity.assert_not_called()
+        self.mock_client.stop_instance.assert_not_called()
+
+    def test_hierarchical_fallback_logging_idle_monitoring_active_retains_vm(self):
+        config = StopperConfig(project_id="test-proj")
+        processor = VMProcessor(config, gce_client=self.mock_client)
+
+        created_ts = (self.now - timedelta(days=15)).isoformat()
+        vm = MockInstance(name="active-net-vm", status="RUNNING", creation_timestamp=created_ts)
+
+        self.mock_client.has_recent_activity.return_value = False
+        self.mock_client.has_network_activity.return_value = (True, 25000000)
+
+        res = processor.process_single_instance("us-central1-a", vm, self.now)
+        self.assertEqual(res["category"], "skipped_active")
+        self.assertIn("Active network traffic detected", res["reason"])
+        self.mock_client.stop_instance.assert_not_called()
+
+    def test_hierarchical_fallback_logging_idle_monitoring_idle_stops_vm(self):
+        config = StopperConfig(project_id="test-proj")
+        processor = VMProcessor(config, gce_client=self.mock_client)
+
+        created_ts = (self.now - timedelta(days=15)).isoformat()
+        vm = MockInstance(name="idle-vm", status="RUNNING", creation_timestamp=created_ts)
+
+        self.mock_client.has_recent_activity.return_value = False
+        self.mock_client.has_network_activity.return_value = (False, 1500000)
+
+        res = processor.process_single_instance("us-central1-a", vm, self.now)
+        self.assertEqual(res["category"], "stopped")
+        self.assertEqual(res["action"], "stopped")
+        self.mock_client.stop_instance.assert_called_once_with("test-proj", "us-central1-a", "idle-vm")
+
+    def test_hierarchical_fallback_monitoring_error_retains_vm(self):
+        config = StopperConfig(project_id="test-proj")
+        processor = VMProcessor(config, gce_client=self.mock_client)
+
+        created_ts = (self.now - timedelta(days=15)).isoformat()
+        vm = MockInstance(name="err-net-vm", status="RUNNING", creation_timestamp=created_ts)
+
+        self.mock_client.has_recent_activity.return_value = False
+        self.mock_client.has_network_activity.return_value = (True, -1)
+
+        res = processor.process_single_instance("us-central1-a", vm, self.now)
+        self.assertEqual(res["category"], "skipped_active")
+        self.assertIn("failing safe (assuming active)", res["reason"])
+        self.mock_client.stop_instance.assert_not_called()
+
+    def test_hierarchical_fallback_disabled_monitoring_bypasses_query(self):
+        config = StopperConfig(project_id="test-proj", enable_network_monitoring=False)
+        processor = VMProcessor(config, gce_client=self.mock_client)
+
+        created_ts = (self.now - timedelta(days=15)).isoformat()
+        vm = MockInstance(name="no-net-mon-vm", status="RUNNING", creation_timestamp=created_ts)
+
+        self.mock_client.has_recent_activity.return_value = False
+        self.mock_client.has_network_activity = MagicMock()
+
+        res = processor.process_single_instance("us-central1-a", vm, self.now)
+        self.assertEqual(res["category"], "stopped")
+        self.mock_client.has_network_activity.assert_not_called()
+        self.mock_client.stop_instance.assert_called_once()
+
+    def test_unconfigured_mock_backward_compatibility(self):
+        config = StopperConfig(project_id="test-proj")
+        unconfigured_client = MagicMock(spec=GCEClient)
+        unconfigured_client.has_recent_activity.return_value = False
+        processor = VMProcessor(config, gce_client=unconfigured_client)
+
+        created_ts = (self.now - timedelta(days=15)).isoformat()
+        vm = MockInstance(name="unconfigured-mock-vm", status="RUNNING", creation_timestamp=created_ts)
+
+        res = processor.process_single_instance("us-central1-a", vm, self.now)
+        self.assertEqual(res["category"], "stopped")
+        unconfigured_client.stop_instance.assert_called_once()
 
 
 class TestDeploymentScriptSyntax(unittest.TestCase):

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -1081,6 +1081,7 @@ class TestVMProcessorLifecycle(unittest.TestCase):
 
     def setUp(self):
         self.mock_client = MagicMock(spec=GCEClient)
+        self.mock_client.has_network_activity.return_value = (False, 0)
         self.now = datetime.now(timezone.utc)
 
     def test_young_running_vm_is_skipped(self):
@@ -1373,7 +1374,7 @@ class TestVMProcessorLifecycle(unittest.TestCase):
             dry_run=False,
             cloud_logging_batch_size=10,
         )
-        mock_client = MagicMock(spec=GCEClient)
+        mock_client = self.mock_client
         processor = VMProcessor(config, gce_client=mock_client)
 
         idle_vm1 = MockInstance("candidate-idle-1", status="RUNNING", creation_timestamp=(self.now - timedelta(days=20)).isoformat())
@@ -2040,19 +2041,6 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
         self.assertEqual(res["category"], "stopped")
         self.mock_client.has_network_activity.assert_not_called()
         self.mock_client.stop_instance.assert_called_once()
-
-    def test_unconfigured_mock_backward_compatibility(self):
-        config = StopperConfig(project_id="test-proj")
-        unconfigured_client = MagicMock(spec=GCEClient)
-        unconfigured_client.has_recent_activity.return_value = False
-        processor = VMProcessor(config, gce_client=unconfigured_client)
-
-        created_ts = (self.now - timedelta(days=15)).isoformat()
-        vm = MockInstance(name="unconfigured-mock-vm", status="RUNNING", creation_timestamp=created_ts)
-
-        res = processor.process_single_instance("us-central1-a", vm, self.now)
-        self.assertEqual(res["category"], "stopped")
-        unconfigured_client.stop_instance.assert_called_once()
 
 
 class TestDeploymentScriptSyntax(unittest.TestCase):

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -1534,6 +1534,57 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
         self.assertIn("compute.googleapis.com/instance/network/received_bytes_count", req.filter)
         self.assertIn("compute.googleapis.com/instance/network/sent_bytes_count", req.filter)
         self.assertIn("inst-12345", req.filter)
+        self.assertEqual(req.aggregation.alignment_period, {"seconds": 3600})
+
+    def test_get_instance_network_bytes_alignment_period_ge_1_hour(self):
+        mock_mon_client = MagicMock()
+        mock_mon_client.list_time_series.return_value = []
+        client = GCEClient(monitoring_client=mock_mon_client)
+
+        # 24 hours interval
+        client.get_instance_network_bytes(
+            "test-proj",
+            "inst-12345",
+            self.now - timedelta(hours=24),
+            self.now,
+        )
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.aggregation.alignment_period, {"seconds": 3600})
+
+        # Exactly 1 hour interval
+        client.get_instance_network_bytes(
+            "test-proj",
+            "inst-12345",
+            self.now - timedelta(hours=1),
+            self.now,
+        )
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.aggregation.alignment_period, {"seconds": 3600})
+
+    def test_get_instance_network_bytes_alignment_period_lt_1_hour(self):
+        mock_mon_client = MagicMock()
+        mock_mon_client.list_time_series.return_value = []
+        client = GCEClient(monitoring_client=mock_mon_client)
+
+        # 5-minute fallback when since_timestamp >= until_timestamp
+        client.get_instance_network_bytes(
+            "test-proj",
+            "inst-12345",
+            self.now,
+            self.now,
+        )
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.aggregation.alignment_period, {"seconds": 60})
+
+        # Explicit interval < 1 hour (e.g. 30 minutes)
+        client.get_instance_network_bytes(
+            "test-proj",
+            "inst-12345",
+            self.now - timedelta(minutes=30),
+            self.now,
+        )
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.aggregation.alignment_period, {"seconds": 60})
 
     def test_has_network_activity_above_threshold(self):
         client = GCEClient()

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -1589,8 +1589,12 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
         call_kwargs = mock_mon_client.list_time_series.call_args[1]
         req = call_kwargs["request"]
         self.assertEqual(req.name, "projects/test-proj")
-        self.assertIn("compute.googleapis.com/instance/network/received_bytes_count", req.filter)
-        self.assertIn("compute.googleapis.com/instance/network/sent_bytes_count", req.filter)
+        self.assertIn(
+            '(metric.type = "compute.googleapis.com/instance/network/received_bytes_count" OR '
+            'metric.type = "compute.googleapis.com/instance/network/sent_bytes_count")',
+            req.filter,
+        )
+        self.assertNotIn("one_of", req.filter)
         self.assertIn("inst-12345", req.filter)
         self.assertEqual(req.aggregation.alignment_period, {"seconds": 3600})
 

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -191,6 +191,7 @@ if _PACKAGE_ROOT not in sys.path:
 from stopper.config import (
     StopperConfig,
     _parse_bool,
+    _parse_bytes,
     _parse_dict,
     _parse_float,
     _parse_int,
@@ -421,6 +422,63 @@ class TestStopperConfig(unittest.TestCase):
 
         self.assertEqual(_parse_dict('{"k": "v"}'), {"k": "v"})
         self.assertEqual(_parse_dict({"a": 1}), {"a": "1"})
+
+    def test_parse_bytes(self):
+        # Suffix handling for GiB, GB, G, MiB, MB, M, KiB, KB, K, B (case-insensitive)
+        self.assertEqual(_parse_bytes("2GiB"), 2 * 1024 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("2gib"), 2 * 1024 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("1GB"), 1024 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("1gb"), 1024 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("3G"), 3 * 1024 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("3g"), 3 * 1024 * 1024 * 1024)
+
+        self.assertEqual(_parse_bytes("10MiB"), 10 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("10mib"), 10 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("5MB"), 5 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("5mb"), 5 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("8M"), 8 * 1024 * 1024)
+        self.assertEqual(_parse_bytes("8m"), 8 * 1024 * 1024)
+
+        self.assertEqual(_parse_bytes("64KiB"), 64 * 1024)
+        self.assertEqual(_parse_bytes("64kib"), 64 * 1024)
+        self.assertEqual(_parse_bytes("32KB"), 32 * 1024)
+        self.assertEqual(_parse_bytes("32kb"), 32 * 1024)
+        self.assertEqual(_parse_bytes("16K"), 16 * 1024)
+        self.assertEqual(_parse_bytes("16k"), 16 * 1024)
+
+        self.assertEqual(_parse_bytes("1024B"), 1024)
+        self.assertEqual(_parse_bytes("512b"), 512)
+
+        # Plain numbers (int, float, numeric string)
+        self.assertEqual(_parse_bytes(1048576), 1048576)
+        self.assertEqual(_parse_bytes(2097152.0), 2097152)
+        self.assertEqual(_parse_bytes("4096"), 4096)
+        self.assertEqual(_parse_bytes("0"), 0)
+        self.assertEqual(_parse_bytes("-1"), -1)
+
+        # Whitespace handling
+        self.assertEqual(_parse_bytes("  10  MB  "), 10 * 1024 * 1024)
+        self.assertEqual(_parse_bytes(" 512 B "), 512)
+        self.assertEqual(_parse_bytes("   100   "), 100)
+
+        # Ensure internal characters are not trimmed (e.g. strings containing suffix chars)
+        self.assertEqual(_parse_bytes("1008B"), 1008)
+        self.assertEqual(_parse_bytes("10.5 MB"), int(10.5 * 1024 * 1024))
+        self.assertEqual(_parse_bytes("1.5 GiB"), int(1.5 * 1024 * 1024 * 1024))
+
+        # Invalid inputs fallback to default
+        self.assertEqual(_parse_bytes(""), 10485760)
+        self.assertEqual(_parse_bytes("   "), 10485760)
+        self.assertEqual(_parse_bytes("invalid"), 10485760)
+        self.assertEqual(_parse_bytes("MB"), 10485760)
+        self.assertEqual(_parse_bytes("GiB"), 10485760)
+        self.assertEqual(_parse_bytes("B"), 10485760)
+        self.assertEqual(_parse_bytes(None), 10485760)
+        self.assertEqual(_parse_bytes(True), 10485760)
+        self.assertEqual(_parse_bytes(False), 10485760)
+        self.assertEqual(_parse_bytes([], default=100), 100)
+        self.assertEqual(_parse_bytes({}, default=100), 100)
+        self.assertEqual(_parse_bytes("abcGB", default=100), 100)
 
 
 class TestGkeAndMigFiltering(unittest.TestCase):

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -1619,6 +1619,240 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
             self.assertTrue(is_active)
             self.assertEqual(count, -1)
 
+    def test_extract_point_value_which_oneof_proto_plus(self):
+        # 1. Proto-plus object with _pb attribute supporting WhichOneof
+        # Case A: int64 active
+        pb_int = MagicMock()
+        pb_int.WhichOneof.return_value = "int64_value"
+        pb_int.int64_value = 1048576
+        val_int = types.SimpleNamespace(_pb=pb_int)
+        point_int = types.SimpleNamespace(value=val_int)
+        self.assertEqual(GCEClient._extract_point_value(point_int), 1048576)
+        pb_int.WhichOneof.assert_called_with("value")
+
+        # Case B: double active
+        # Note: on proto-plus objects, accessing unset int64_value returns 0.
+        # Ensure that WhichOneof correctly extracts double_value even when int64_value=0.
+        pb_double = MagicMock()
+        pb_double.WhichOneof.return_value = "double_value"
+        pb_double.double_value = 2097152.0
+        val_double = types.SimpleNamespace(_pb=pb_double, int64_value=0, double_value=2097152.0)
+        point_double = types.SimpleNamespace(value=val_double)
+        self.assertEqual(GCEClient._extract_point_value(point_double), 2097152)
+        pb_double.WhichOneof.assert_called_with("value")
+
+        # 2. Direct protobuf object (without _pb attribute) supporting WhichOneof
+        pb_direct_int = MagicMock()
+        pb_direct_int.WhichOneof.return_value = "int64_value"
+        pb_direct_int.int64_value = 524288
+        del pb_direct_int._pb  # Ensure no _pb
+        point_direct_int = types.SimpleNamespace(value=pb_direct_int)
+        self.assertEqual(GCEClient._extract_point_value(point_direct_int), 524288)
+
+        pb_direct_double = MagicMock()
+        pb_direct_double.WhichOneof.return_value = "double_value"
+        pb_direct_double.double_value = 65536.0
+        del pb_direct_double._pb
+        point_direct_double = types.SimpleNamespace(value=pb_direct_double)
+        self.assertEqual(GCEClient._extract_point_value(point_direct_double), 65536)
+
+        # 3. WhichOneof raises ValueError/TypeError, falls back to attributes
+        pb_err = MagicMock()
+        pb_err.WhichOneof.side_effect = ValueError("Invalid field")
+        pb_err.int64_value = 4096
+        val_err = types.SimpleNamespace(_pb=pb_err, int64_value=4096)
+        point_err = types.SimpleNamespace(value=val_err)
+        self.assertEqual(GCEClient._extract_point_value(point_err), 4096)
+
+        # 4. Fallback attribute access on simple mocks without WhichOneof
+        self.assertEqual(GCEClient._extract_point_value(types.SimpleNamespace(value=types.SimpleNamespace(int64_value=123))), 123)
+        self.assertEqual(GCEClient._extract_point_value(types.SimpleNamespace(value=types.SimpleNamespace(double_value=456.7))), 456)
+        self.assertEqual(GCEClient._extract_point_value(types.SimpleNamespace(value=types.SimpleNamespace(int64Value=789))), 789)
+        self.assertEqual(GCEClient._extract_point_value(types.SimpleNamespace(value=types.SimpleNamespace(doubleValue=321.4))), 321)
+
+    def test_extract_point_value_dicts_and_scalars(self):
+        # Dict inputs with nested value dict
+        self.assertEqual(GCEClient._extract_point_value({"value": {"int64Value": 100}}), 100)
+        self.assertEqual(GCEClient._extract_point_value({"value": {"int64_value": 200}}), 200)
+        self.assertEqual(GCEClient._extract_point_value({"value": {"doubleValue": 300.7}}), 300)
+        self.assertEqual(GCEClient._extract_point_value({"value": {"double_value": 400.2}}), 400)
+        self.assertEqual(GCEClient._extract_point_value({"value": {}}), 0)
+        self.assertEqual(GCEClient._extract_point_value({"value": 500}), 500)
+        self.assertEqual(GCEClient._extract_point_value({"value": None}), 0)
+        self.assertEqual(GCEClient._extract_point_value({}), 0)
+
+        # Scalar inputs
+        self.assertEqual(GCEClient._extract_point_value(1024), 1024)
+        self.assertEqual(GCEClient._extract_point_value(2048.9), 2048)
+        self.assertEqual(GCEClient._extract_point_value(None), 0)
+
+        # Object with scalar value attribute
+        self.assertEqual(GCEClient._extract_point_value(types.SimpleNamespace(value=4096)), 4096)
+        self.assertEqual(GCEClient._extract_point_value(types.SimpleNamespace(value=8192.5)), 8192)
+        self.assertEqual(GCEClient._extract_point_value(types.SimpleNamespace(value=None)), 0)
+        self.assertEqual(GCEClient._extract_point_value(object()), 0)
+
+    def test_get_instance_network_bytes_explicit_and_keyword_args(self):
+        mock_mon_client = MagicMock()
+        mock_mon_client.list_time_series.return_value = []
+        client = GCEClient(monitoring_client=mock_mon_client)
+
+        start_ts = self.now - timedelta(hours=12)
+        end_ts = self.now
+
+        # 1. Explicit positional arguments
+        total = client.get_instance_network_bytes("proj-pos", "inst-pos", start_ts, end_ts, "us-central1-a", 12)
+        self.assertEqual(total, 0)
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.name, "projects/proj-pos")
+        self.assertIn("inst-pos", req.filter)
+        self.assertEqual(req.interval.start_time, start_ts)
+        self.assertEqual(req.interval.end_time, end_ts)
+
+        # 2. Keyword arguments
+        mock_mon_client.reset_mock()
+        total = client.get_instance_network_bytes(
+            project_id="proj-kw",
+            instance_id="inst-kw",
+            since_timestamp=start_ts,
+            until_timestamp=end_ts,
+            zone="us-east1-b",
+            lookback_hours=12,
+        )
+        self.assertEqual(total, 0)
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.name, "projects/proj-kw")
+        self.assertIn("inst-kw", req.filter)
+        self.assertEqual(req.interval.start_time, start_ts)
+        self.assertEqual(req.interval.end_time, end_ts)
+
+        # 3. Default arguments with lookback_hours
+        mock_mon_client.reset_mock()
+        total = client.get_instance_network_bytes(
+            project_id="proj-lookback",
+            instance_id="inst-lookback",
+            until_timestamp=end_ts,
+            lookback_hours=6,
+        )
+        self.assertEqual(total, 0)
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.interval.start_time, end_ts - timedelta(hours=6))
+        self.assertEqual(req.interval.end_time, end_ts)
+
+        # 4. Default 24h lookback when since_timestamp is None
+        mock_mon_client.reset_mock()
+        total = client.get_instance_network_bytes(
+            project_id="proj-default",
+            instance_id="inst-default",
+            until_timestamp=end_ts,
+        )
+        self.assertEqual(total, 0)
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.interval.start_time, end_ts - timedelta(hours=24))
+        self.assertEqual(req.interval.end_time, end_ts)
+
+        # 5. Fallback when since_timestamp >= until_timestamp
+        mock_mon_client.reset_mock()
+        total = client.get_instance_network_bytes(
+            project_id="proj-fallback",
+            instance_id="inst-fallback",
+            since_timestamp=end_ts,
+            until_timestamp=end_ts,
+        )
+        self.assertEqual(total, 0)
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.interval.start_time, end_ts - timedelta(minutes=5))
+
+    def test_has_network_activity_explicit_and_keyword_args(self):
+        client = GCEClient()
+
+        # 1. Explicit positional arguments
+        with patch.object(client, "get_instance_network_bytes", return_value=20000000) as mock_get_bytes:
+            start_ts = self.now - timedelta(hours=8)
+            end_ts = self.now
+            is_active, count = client.has_network_activity(
+                "proj-pos",
+                "inst-pos-id",
+                "vm-pos-name",
+                "us-central1-b",
+                start_ts,
+                15000000,
+                end_ts,
+                8,
+            )
+            self.assertTrue(is_active)
+            self.assertEqual(count, 20000000)
+            mock_get_bytes.assert_called_once_with(
+                project_id="proj-pos",
+                instance_id="inst-pos-id",
+                since_timestamp=start_ts,
+                until_timestamp=end_ts,
+                zone="us-central1-b",
+                lookback_hours=8,
+            )
+
+        # 2. Keyword arguments
+        with patch.object(client, "get_instance_network_bytes", return_value=5000000) as mock_get_bytes:
+            start_ts = self.now - timedelta(hours=10)
+            end_ts = self.now
+            is_active, count = client.has_network_activity(
+                project_id="proj-kw",
+                instance_id="inst-kw-id",
+                instance_name="vm-kw-name",
+                zone="europe-west1-b",
+                since_timestamp=start_ts,
+                threshold_bytes=10000000,
+                until_timestamp=end_ts,
+                lookback_hours=10,
+            )
+            self.assertFalse(is_active)
+            self.assertEqual(count, 5000000)
+            mock_get_bytes.assert_called_once_with(
+                project_id="proj-kw",
+                instance_id="inst-kw-id",
+                since_timestamp=start_ts,
+                until_timestamp=end_ts,
+                zone="europe-west1-b",
+                lookback_hours=10,
+            )
+
+        # 3. Defaults when only required args provided
+        with patch.object(client, "get_instance_network_bytes", return_value=10485760) as mock_get_bytes:
+            is_active, count = client.has_network_activity(
+                project_id="proj-req",
+                instance_id="123456789",
+            )
+            self.assertTrue(is_active)
+            self.assertEqual(count, 10485760)
+            mock_get_bytes.assert_called_once_with(
+                project_id="proj-req",
+                instance_id="123456789",
+                since_timestamp=None,
+                until_timestamp=None,
+                zone="unknown",
+                lookback_hours=None,
+            )
+
+        # 4. Explicit None for optional args defaults properly
+        with patch.object(client, "get_instance_network_bytes", return_value=10485759) as mock_get_bytes:
+            is_active, count = client.has_network_activity(
+                project_id="proj-none",
+                instance_id="987654321",
+                instance_name=None,
+                zone=None,
+                threshold_bytes=None,
+            )
+            self.assertFalse(is_active)
+            self.assertEqual(count, 10485759)
+            mock_get_bytes.assert_called_once_with(
+                project_id="proj-none",
+                instance_id="987654321",
+                since_timestamp=None,
+                until_timestamp=None,
+                zone="unknown",
+                lookback_hours=None,
+            )
+
     def test_hierarchical_fallback_logging_active_skips_monitoring(self):
         config = StopperConfig(project_id="test-proj")
         processor = VMProcessor(config, gce_client=self.mock_client)

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -1649,6 +1649,17 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
         req = mock_mon_client.list_time_series.call_args[1]["request"]
         self.assertEqual(req.aggregation.alignment_period, {"seconds": 60})
 
+        # Interval < 60 seconds (e.g. 30s) adjusted to 5 minutes before until_timestamp
+        client.get_instance_network_bytes(
+            "test-proj",
+            "inst-12345",
+            self.now - timedelta(seconds=30),
+            self.now,
+        )
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.interval.start_time, self.now - timedelta(minutes=5))
+        self.assertEqual(req.aggregation.alignment_period, {"seconds": 60})
+
     def test_has_network_activity_above_threshold(self):
         client = GCEClient()
         with patch.object(client, "get_instance_network_bytes", return_value=15000000):
@@ -1871,6 +1882,18 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
             project_id="proj-fallback",
             instance_id="inst-fallback",
             since_timestamp=end_ts,
+            until_timestamp=end_ts,
+        )
+        self.assertEqual(total, 0)
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req.interval.start_time, end_ts - timedelta(minutes=5))
+
+        # 6. Fallback when interval < 60 seconds
+        mock_mon_client.reset_mock()
+        total = client.get_instance_network_bytes(
+            project_id="proj-fallback-short",
+            instance_id="inst-fallback-short",
+            since_timestamp=end_ts - timedelta(seconds=30),
             until_timestamp=end_ts,
         )
         self.assertEqual(total, 0)

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -1781,13 +1781,55 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
         point_direct_double = types.SimpleNamespace(value=pb_direct_double)
         self.assertEqual(GCEClient._extract_point_value(point_direct_double), 65536)
 
-        # 3. WhichOneof raises ValueError/TypeError, falls back to attributes
+        # 3. WhichOneof raises ValueError/TypeError/AttributeError, falls back to attributes
         pb_err = MagicMock()
         pb_err.WhichOneof.side_effect = ValueError("Invalid field")
         pb_err.int64_value = 4096
         val_err = types.SimpleNamespace(_pb=pb_err, int64_value=4096)
         point_err = types.SimpleNamespace(value=val_err)
         self.assertEqual(GCEClient._extract_point_value(point_err), 4096)
+
+        pb_attr_err = MagicMock()
+        pb_attr_err.WhichOneof.side_effect = AttributeError("Unexpected attribute error")
+        pb_attr_err.int64_value = 8192
+        val_attr_err = types.SimpleNamespace(_pb=pb_attr_err, int64_value=8192)
+        point_attr_err = types.SimpleNamespace(value=val_attr_err)
+        self.assertEqual(GCEClient._extract_point_value(point_attr_err), 8192)
+
+    def test_extract_point_value_which_oneof_attribute_error_nonexistent_field(self):
+        class NonExistentFieldPb:
+            def WhichOneof(self, field_name):
+                return "non_existent_field"
+            int64_value = 8192
+
+        # 1. WhichOneof returns a field name that does not exist on pb_val, getattr raises AttributeError
+        val_with_fallback = types.SimpleNamespace(_pb=NonExistentFieldPb(), int64_value=8192)
+        point_with_fallback = types.SimpleNamespace(value=val_with_fallback)
+        self.assertEqual(GCEClient._extract_point_value(point_with_fallback), 8192)
+
+        # 2. Direct pb object (without _pb attribute) where WhichOneof returns non-existent field
+        pb_direct = NonExistentFieldPb()
+        point_direct = types.SimpleNamespace(value=pb_direct)
+        self.assertEqual(GCEClient._extract_point_value(point_direct), 8192)
+
+        # 3. Non-existent field on pb with no fallback attributes anywhere returns 0
+        class PbNoFallback:
+            def WhichOneof(self, field_name):
+                return "does_not_exist"
+
+        val_no_fallback = types.SimpleNamespace(_pb=PbNoFallback())
+        point_no_fallback = types.SimpleNamespace(value=val_no_fallback)
+        self.assertEqual(GCEClient._extract_point_value(point_no_fallback), 0)
+
+        # 4. Empty string returned by WhichOneof (e.g. no field set in oneof) skips getattr and falls back
+        class PbEmptyWhichOneof:
+            def WhichOneof(self, field_name):
+                return ""
+            double_value = 1234.5
+
+        val_empty = types.SimpleNamespace(_pb=PbEmptyWhichOneof(), double_value=1234.5)
+        point_empty = types.SimpleNamespace(value=val_empty)
+        self.assertEqual(GCEClient._extract_point_value(point_empty), 1234)
 
         # 4. Fallback attribute access on simple mocks without WhichOneof
         self.assertEqual(GCEClient._extract_point_value(types.SimpleNamespace(value=types.SimpleNamespace(int64_value=123))), 123)
@@ -1899,6 +1941,82 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
         self.assertEqual(total, 0)
         req = mock_mon_client.list_time_series.call_args[1]["request"]
         self.assertEqual(req.interval.start_time, end_ts - timedelta(minutes=5))
+
+    def test_get_instance_network_bytes_non_utc_timezone_normalization(self):
+        mock_mon_client = MagicMock()
+        mock_mon_client.list_time_series.return_value = []
+        client = GCEClient(monitoring_client=mock_mon_client)
+
+        tz_plus_5 = timezone(timedelta(hours=5))
+        since_ts = datetime(2026, 9, 10, 10, 0, 0, tzinfo=tz_plus_5)
+        until_ts = datetime(2026, 9, 10, 16, 0, 0, tzinfo=tz_plus_5)
+
+        client.get_instance_network_bytes(
+            project_id="test-proj",
+            instance_id="inst-tz",
+            since_timestamp=since_ts,
+            until_timestamp=until_ts,
+        )
+
+        req = mock_mon_client.list_time_series.call_args[1]["request"]
+        expected_since_utc = since_ts.astimezone(timezone.utc)
+        expected_until_utc = until_ts.astimezone(timezone.utc)
+
+        self.assertEqual(req.interval.start_time, expected_since_utc)
+        self.assertEqual(req.interval.start_time.tzinfo, timezone.utc)
+        self.assertEqual(req.interval.start_time.hour, 5)
+        self.assertEqual(req.interval.end_time, expected_until_utc)
+        self.assertEqual(req.interval.end_time.tzinfo, timezone.utc)
+        self.assertEqual(req.interval.end_time.hour, 11)
+
+        # Naive datetimes (without tzinfo) should be treated as UTC
+        mock_mon_client.reset_mock()
+        naive_since = datetime(2026, 9, 10, 5, 0, 0)
+        naive_until = datetime(2026, 9, 10, 11, 0, 0)
+        client.get_instance_network_bytes(
+            project_id="test-proj",
+            instance_id="inst-tz-naive",
+            since_timestamp=naive_since,
+            until_timestamp=naive_until,
+        )
+        req_naive = mock_mon_client.list_time_series.call_args[1]["request"]
+        self.assertEqual(req_naive.interval.start_time, naive_since.replace(tzinfo=timezone.utc))
+        self.assertEqual(req_naive.interval.start_time.tzinfo, timezone.utc)
+        self.assertEqual(req_naive.interval.end_time, naive_until.replace(tzinfo=timezone.utc))
+        self.assertEqual(req_naive.interval.end_time.tzinfo, timezone.utc)
+
+    def test_monitoring_v3_import_error_when_none(self):
+        with patch("stopper.gce_client.monitoring_v3", None):
+            client = GCEClient()
+            with self.assertRaises(ImportError) as ctx_prop:
+                _ = client.monitoring_client
+            self.assertIn("google-cloud-monitoring is not installed", str(ctx_prop.exception))
+
+            with self.assertRaises(ImportError) as ctx_prop_creds:
+                client_with_creds = GCEClient(credentials=MagicMock())
+                _ = client_with_creds.monitoring_client
+            self.assertIn("google-cloud-monitoring is not installed", str(ctx_prop_creds.exception))
+
+            with self.assertRaises(ImportError) as ctx_method:
+                client.get_instance_network_bytes("test-proj", "inst-12345")
+            self.assertIn("google-cloud-monitoring is not installed", str(ctx_method.exception))
+
+    def test_monitoring_client_lazy_initialization(self):
+        mock_v3 = MagicMock()
+        with patch("stopper.gce_client.monitoring_v3", mock_v3):
+            # Without credentials
+            client = GCEClient()
+            mon_c = client.monitoring_client
+            mock_v3.MetricServiceClient.assert_called_once_with()
+            self.assertEqual(mon_c, mock_v3.MetricServiceClient.return_value)
+
+            # With credentials
+            mock_v3.reset_mock()
+            mock_creds = MagicMock()
+            client_with_creds = GCEClient(credentials=mock_creds)
+            mon_c2 = client_with_creds.monitoring_client
+            mock_v3.MetricServiceClient.assert_called_once_with(credentials=mock_creds)
+            self.assertEqual(mon_c2, mock_v3.MetricServiceClient.return_value)
 
     def test_has_network_activity_explicit_and_keyword_args(self):
         client = GCEClient()

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -135,7 +135,10 @@ def _setup_offline_mock_modules() -> None:
 
                 def __init__(self, **kwargs):
                     for k, v in kwargs.items():
-                        setattr(self, k, v)
+                        if k == "alignment_period" and isinstance(v, dict) and "seconds" in v:
+                            setattr(self, k, timedelta(seconds=v["seconds"]))
+                        else:
+                            setattr(self, k, v)
 
             mon_mod.Aggregation = MockAggregation
 
@@ -1510,6 +1513,18 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
         self.now = datetime(2026, 9, 10, 12, 0, 0, tzinfo=timezone.utc)
         self.mock_client = MagicMock(spec=GCEClient)
 
+    def _assert_alignment_period_seconds(self, alignment_period: Any, expected_seconds: int) -> None:
+        if isinstance(alignment_period, timedelta):
+            self.assertEqual(int(alignment_period.total_seconds()), expected_seconds)
+        elif isinstance(alignment_period, dict):
+            self.assertEqual(alignment_period.get("seconds"), expected_seconds)
+        elif hasattr(alignment_period, "total_seconds"):
+            self.assertEqual(int(alignment_period.total_seconds()), expected_seconds)
+        elif hasattr(alignment_period, "seconds"):
+            self.assertEqual(alignment_period.seconds, expected_seconds)
+        else:
+            self.assertEqual(alignment_period, expected_seconds)
+
     def test_config_network_telemetry_defaults(self):
         config = StopperConfig(project_id="test-proj")
         self.assertEqual(config.network_bytes_threshold, 10485760)
@@ -1597,7 +1612,7 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
         )
         self.assertNotIn("one_of", req.filter)
         self.assertIn("inst-12345", req.filter)
-        self.assertEqual(req.aggregation.alignment_period, {"seconds": 3600})
+        self._assert_alignment_period_seconds(req.aggregation.alignment_period, 3600)
 
     def test_get_instance_network_bytes_alignment_period_ge_1_hour(self):
         mock_mon_client = MagicMock()
@@ -1612,7 +1627,7 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
             self.now,
         )
         req = mock_mon_client.list_time_series.call_args[1]["request"]
-        self.assertEqual(req.aggregation.alignment_period, {"seconds": 3600})
+        self._assert_alignment_period_seconds(req.aggregation.alignment_period, 3600)
 
         # Exactly 1 hour interval
         client.get_instance_network_bytes(
@@ -1622,7 +1637,7 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
             self.now,
         )
         req = mock_mon_client.list_time_series.call_args[1]["request"]
-        self.assertEqual(req.aggregation.alignment_period, {"seconds": 3600})
+        self._assert_alignment_period_seconds(req.aggregation.alignment_period, 3600)
 
     def test_get_instance_network_bytes_alignment_period_lt_1_hour(self):
         mock_mon_client = MagicMock()
@@ -1637,7 +1652,7 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
             self.now,
         )
         req = mock_mon_client.list_time_series.call_args[1]["request"]
-        self.assertEqual(req.aggregation.alignment_period, {"seconds": 60})
+        self._assert_alignment_period_seconds(req.aggregation.alignment_period, 60)
 
         # Explicit interval < 1 hour (e.g. 30 minutes)
         client.get_instance_network_bytes(
@@ -1647,7 +1662,7 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
             self.now,
         )
         req = mock_mon_client.list_time_series.call_args[1]["request"]
-        self.assertEqual(req.aggregation.alignment_period, {"seconds": 60})
+        self._assert_alignment_period_seconds(req.aggregation.alignment_period, 60)
 
         # Interval < 60 seconds (e.g. 30s) adjusted to 5 minutes before until_timestamp
         client.get_instance_network_bytes(
@@ -1658,7 +1673,7 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
         )
         req = mock_mon_client.list_time_series.call_args[1]["request"]
         self.assertEqual(req.interval.start_time, self.now - timedelta(minutes=5))
-        self.assertEqual(req.aggregation.alignment_period, {"seconds": 60})
+        self._assert_alignment_period_seconds(req.aggregation.alignment_period, 60)
 
     def test_has_network_activity_above_threshold(self):
         client = GCEClient()


### PR DESCRIPTION
### Summary
Enhance `vm-stopper` to detect interactive direct SSH and VS Code Remote SSH sessions that do not generate Cloud Audit Logs (Pantheon / Cloud Console logs), using Cloud Monitoring network metrics (`compute.googleapis.com/instance/network/received_bytes_count` and `sent_bytes_count`) alongside Cloud Logging.