### PR TITLE
fix(vm-stopper): query network metrics separately in Cloud Monitoring

### DIFF
--- a/cloud-run-services/vm-stopper/stopper/gce_client.py
+++ b/cloud-run-services/vm-stopper/stopper/gce_client.py
@@ -456,42 +456,47 @@ class GCEClient:
             per_series_aligner=aligner,
         )
 
-        filter_expr = (
-            f'(metric.type = "{METRIC_RECEIVED_BYTES}" OR metric.type = "{METRIC_SENT_BYTES}") '
-            f'AND resource.type = "gce_instance" '
-            f'AND resource.labels.instance_id = "{instance_id}"'
-        )
-
-        if self.rate_limiter:
-            self.rate_limiter.acquire()
-
         view = getattr(
             getattr(monitoring_v3.ListTimeSeriesRequest, "TimeSeriesView", None),
             "FULL",
             2,
         )
-        request = monitoring_v3.ListTimeSeriesRequest(
-            name=f"projects/{project_id}",
-            filter=filter_expr,
-            interval=interval,
-            aggregation=aggregation,
-            view=view,
-        )
-
-        pager = self.monitoring_client.list_time_series(request=request)
         total_bytes = 0
 
-        if pager is not None:
-            try:
-                for series in pager:
-                    if isinstance(series, dict):
-                        points = series.get("points", [])
-                    else:
-                        points = getattr(series, "points", [])
-                    for pt in points:
-                        total_bytes += self._extract_point_value(pt)
-            except (TypeError, AttributeError):
-                pass
+        # Cloud Monitoring ListTimeSeries filter syntax enforces at most ONE metric.type comparison
+        # per request. Disjunctions ('OR') between different metric types are rejected with HTTP 400 Bad Request
+        # ("Within the 'metric' prefix, OR can only be used to connect a list of 'labels' restrictions").
+        # Therefore, we query received and sent bytes in separate requests and aggregate their totals.
+        for metric_type in (METRIC_RECEIVED_BYTES, METRIC_SENT_BYTES):
+            filter_expr = (
+                f'metric.type = "{metric_type}" '
+                f'AND resource.type = "gce_instance" '
+                f'AND resource.labels.instance_id = "{instance_id}"'
+            )
+
+            if self.rate_limiter:
+                self.rate_limiter.acquire()
+
+            request = monitoring_v3.ListTimeSeriesRequest(
+                name=f"projects/{project_id}",
+                filter=filter_expr,
+                interval=interval,
+                aggregation=aggregation,
+                view=view,
+            )
+
+            pager = self.monitoring_client.list_time_series(request=request)
+            if pager is not None:
+                try:
+                    for series in pager:
+                        if isinstance(series, dict):
+                            points = series.get("points", [])
+                        else:
+                            points = getattr(series, "points", [])
+                        for pt in points:
+                            total_bytes += self._extract_point_value(pt)
+                except (TypeError, AttributeError):
+                    pass
 
         return total_bytes
 

--- a/cloud-run-services/vm-stopper/stopper/vm_processor.py
+++ b/cloud-run-services/vm-stopper/stopper/vm_processor.py
@@ -331,29 +331,19 @@ class VMProcessor:
                     else idle_cutoff
                 )
 
-                try:
-                    net_result = self.client.has_network_activity(
-                        project_id=self.config.project_id,
-                        instance_id=inst_id,
-                        instance_name=name,
-                        zone=zone,
-                        since_timestamp=network_cutoff,
-                        threshold_bytes=self.config.network_bytes_threshold,
-                    )
-                    if isinstance(net_result, tuple):
-                        has_net_activity, net_bytes = net_result
-                    else:
-                        has_net_activity = bool(net_result)
-                        net_bytes = self.config.network_bytes_threshold if has_net_activity else 0
-                except Exception as exc:
-                    logger.warning(
-                        "Cloud Monitoring query failed for instance %s in zone %s: %s. "
-                        "Failing safe: assuming instance is ACTIVE.",
-                        name,
-                        zone,
-                        exc,
-                    )
-                    has_net_activity, net_bytes = True, -1
+                net_result = self.client.has_network_activity(
+                    project_id=self.config.project_id,
+                    instance_id=inst_id,
+                    instance_name=name,
+                    zone=zone,
+                    since_timestamp=network_cutoff,
+                    threshold_bytes=self.config.network_bytes_threshold,
+                )
+                if isinstance(net_result, tuple):
+                    has_net_activity, net_bytes = net_result
+                else:
+                    has_net_activity = bool(net_result)
+                    net_bytes = self.config.network_bytes_threshold if has_net_activity else 0
 
                 if has_net_activity:
                     result["category"] = "skipped_active"

--- a/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
+++ b/cloud-run-services/vm-stopper/tests/test_vm_stopper.py
@@ -200,7 +200,13 @@ from stopper.config import (
     _parse_int,
     _parse_list,
 )
-from stopper.gce_client import GCEClient, RateLimiter, is_rate_limit_error
+from stopper.gce_client import (
+    GCEClient,
+    METRIC_RECEIVED_BYTES,
+    METRIC_SENT_BYTES,
+    RateLimiter,
+    is_rate_limit_error,
+)
 from stopper.service import process_request
 from stopper.vm_processor import (
     VMProcessor,
@@ -1591,7 +1597,16 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
                 {"value": {"int64Value": 7000000}},
             ]
         }
-        mock_mon_client.list_time_series.return_value = [mock_series_rx, mock_series_tx]
+
+        def list_time_series_side_effect(*args, **kwargs):
+            req = kwargs.get("request") if "request" in kwargs else (args[0] if args else None)
+            if req and METRIC_RECEIVED_BYTES in req.filter:
+                return [mock_series_rx]
+            if req and METRIC_SENT_BYTES in req.filter:
+                return [mock_series_tx]
+            return []
+
+        mock_mon_client.list_time_series.side_effect = list_time_series_side_effect
 
         client = GCEClient(monitoring_client=mock_mon_client)
         total = client.get_instance_network_bytes(
@@ -1601,18 +1616,25 @@ class TestCloudMonitoringNetworkTelemetry(unittest.TestCase):
             self.now,
         )
         self.assertEqual(total, 12000000)
-        mock_mon_client.list_time_series.assert_called_once()
-        call_kwargs = mock_mon_client.list_time_series.call_args[1]
-        req = call_kwargs["request"]
-        self.assertEqual(req.name, "projects/test-proj")
-        self.assertIn(
-            '(metric.type = "compute.googleapis.com/instance/network/received_bytes_count" OR '
-            'metric.type = "compute.googleapis.com/instance/network/sent_bytes_count")',
-            req.filter,
-        )
-        self.assertNotIn("one_of", req.filter)
-        self.assertIn("inst-12345", req.filter)
-        self._assert_alignment_period_seconds(req.aggregation.alignment_period, 3600)
+        self.assertEqual(mock_mon_client.list_time_series.call_count, 2)
+
+        call_0_req = mock_mon_client.list_time_series.call_args_list[0][1]["request"]
+        call_1_req = mock_mon_client.list_time_series.call_args_list[1][1]["request"]
+
+        # Verify call 0 queries METRIC_RECEIVED_BYTES and call 1 queries METRIC_SENT_BYTES
+        self.assertIn(METRIC_RECEIVED_BYTES, call_0_req.filter)
+        self.assertNotIn(METRIC_SENT_BYTES, call_0_req.filter)
+        self.assertIn(METRIC_SENT_BYTES, call_1_req.filter)
+        self.assertNotIn(METRIC_RECEIVED_BYTES, call_1_req.filter)
+
+        # Verify that neither request filter contains OR or one_of
+        for req in (call_0_req, call_1_req):
+            self.assertEqual(req.name, "projects/test-proj")
+            self.assertNotIn("OR", req.filter)
+            self.assertNotIn("one_of", req.filter)
+            self.assertIn("inst-12345", req.filter)
+            self.assertIn('resource.type = "gce_instance"', req.filter)
+            self._assert_alignment_period_seconds(req.aggregation.alignment_period, 3600)
 
     def test_get_instance_network_bytes_alignment_period_ge_1_hour(self):
         mock_mon_client = MagicMock()


### PR DESCRIPTION
## Description
This pull request addresses two issues in the `vm-stopper` Cloud Monitoring network telemetry integration:

1. **Fix Cloud Monitoring 400 Bad Request filter error**:
   In Google Cloud Monitoring, `list_time_series` filter syntax strictly enforces at most one `metric.type` comparison per request. Using `OR` between distinct metric types fails with:
   `400 Field filter had an invalid value ... Within the 'metric' prefix, OR can only be used to connect a list of 'labels' restrictions.`
   To adhere to this constraint, `get_instance_network_bytes` now queries `received_bytes_count` and `sent_bytes_count` in separate requests with token acquisition from the rate limiter and aggregates their point sums.

2. **Remove redundant try-except block**:
   In `VMProcessor.process_single_instance`, removed the redundant `try-except` block wrapping `has_network_activity`. `has_network_activity` already catches all exceptions internally, logs the fail-safe warning, and returns `(True, -1)` (assuming active to prevent accidental VM stoppage).

3. **Tests & Assertions**:
   - Updated `test_get_instance_network_bytes_aggregation` to mock and assert both individual metric queries without `OR` or `one_of`.
   - Supported `datetime.timedelta` in proto-plus duration comparisons.

## Verification
- `python3 -m unittest discover -s tests -p "test_*.py"`: 88/88 passed
- `python3 -m pytest tests/`: 88/88 passed
- `python3 verify_deployment_artifacts.py`: 30/30 passed