### PR TITLE
fix(bucket-cleaner): restore --condition=None for non-interactive IAM policy bindings

### DIFF
--- a/cloud-run-services/bucket-cleaner/deploy.sh
+++ b/cloud-run-services/bucket-cleaner/deploy.sh
@@ -271,7 +271,7 @@ ensure_project_iam_role() {
 
   if [[ "${DRY_RUN}" == "true" ]]; then
     log_dry_run "Checking IAM role '${role}' on '${member}' in project '${project}'..."
-    log_dry_run "If missing, would prompt user for permission and execute: gcloud projects add-iam-policy-binding ${project} --member=${member} --role=${role} --quiet"
+    log_dry_run "If missing, would prompt user for permission and execute: gcloud projects add-iam-policy-binding ${project} --member=${member} --role=${role} --condition=None --quiet"
     return 0
   fi
 
@@ -291,12 +291,13 @@ ensure_project_iam_role() {
     if gcloud projects add-iam-policy-binding "${project}" \
         --member="${member}" \
         --role="${role}" \
+        --condition=None \
         --quiet >/dev/null; then
       log "Successfully granted IAM role '${role}' to '${member}'."
     else
       log "WARNING: Failed to grant IAM role '${role}' to '${member}'."
       log "If you lack 'resourcemanager.projects.setIamPolicy', please request a Project IAM Admin run:"
-      log "  gcloud projects add-iam-policy-binding ${project} --member=\"${member}\" --role=\"${role}\""
+      log "  gcloud projects add-iam-policy-binding ${project} --member=\"${member}\" --role=\"${role}\" --condition=None"
     fi
   else
     log "Permission declined by user for role '${role}' on '${member}'. Proceeding without granting."

--- a/cloud-run-services/cloudbuild.yaml
+++ b/cloud-run-services/cloudbuild.yaml
@@ -208,6 +208,7 @@ steps:
             gcloud projects add-iam-policy-binding "${_PROJECT_ID}" \
               --member="serviceAccount:${email}" \
               --role="${role}" \
+              --condition=None \
               --quiet >/dev/null
           done
         done


### PR DESCRIPTION
## Summary
Adding unconditional IAM policy bindings in `gcloud` non-interactive mode (`--quiet`) fails when a project contains existing conditional policies:
```
ERROR: (gcloud.projects.add-iam-policy-binding) Adding a binding without specifying a condition to a policy containing conditions is prohibited in non-interactive mode. Run the command again with --condition=None
```
This PR restores `--condition=None` in `cloudbuild.yaml` and `deploy.sh` so that Cloud Build Step 7 (`provision-iam-service-accounts`) succeeds and completes the deployment of the bucket-cleaner service and its Cloud Scheduler trigger.

## Verification
- Validated bash syntax for `cloud-run-services/bucket-cleaner/deploy.sh`.
- All 14 bucket-cleaner unit tests pass.